### PR TITLE
Call realpath() with full /sys/* path instead of device name

### DIFF
--- a/smartmontools/os_linux.cpp
+++ b/smartmontools/os_linux.cpp
@@ -3209,7 +3209,7 @@ static bool is_hpsa(const char * name)
 {
   char path[128];
   snprintf(path, sizeof(path), "/sys/block/%s/device", name);
-  char * syshostpath = realpath(name, (char *)0);
+  char * syshostpath = realpath(path, (char *)0);
   if (!syshostpath)
     return false;
 


### PR DESCRIPTION
This fixes detection of hpsa devices in Linux.