### PR TITLE
modify and add IDs of innodisk 3TG6.

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -951,13 +951,16 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 12,raw48,Power_Cycle_Count "
     "-v 160,raw48,Uncorrectable_Error_Cnt "
     "-v 161,raw48,Number_of_Pure_Spare "
-    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 163,raw48,Total_Bad_Block_Count "
     "-v 164,raw48,Total_Erase_Count "
     "-v 165,raw48,Max_Erase_Count "
     "-v 166,raw48,Min_Erase_Count "
     "-v 167,raw48,Average_Erase_Count "
     "-v 168,raw48,Max_Erase_Count_of_Spec "
     "-v 169,raw48,Remaining_Lifetime_Perc "
+    "-v 170,raw48,Spare_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
   //"-v 175,raw48,Program_Fail_Count_Chip "
   //"-v 176,raw48,Erase_Fail_Count_Chip "
   //"-v 177,raw48,Wear_Leveling_Count "
@@ -973,9 +976,11 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 198,raw48,Offline_Uncorrectable "
   //"-v 199,raw48,UDMA_CRC_Error_Count "
     "-v 225,raw48,Host_Writes_32MiB "  // ]
+    "-v 229,raw48,Flash_ID "  // ]
   //"-v 232,raw48,Available_Reservd_Space "
     "-v 233,raw48,Flash_Writes_32MiB " // ]
     "-v 234,raw48,Flash_Reads_32MiB "  // ]
+    "-v 235,raw48,Later_Bad_Block_Info "  // ]
     "-v 241,raw48,Host_Writes_32MiB "
     "-v 242,raw48,Host_Reads_32MiB "
     "-v 245,raw48,Flash_Writes_32MiB "


### PR DESCRIPTION
modify ID163 naming
add ID 170 - 172, 229, 235

---

Hi, it's me again, This time, I have updated the version of smartctl for testing output as below.
Big thx for your support and merge.

**Testing output:**
smartctl 7.0 2018-12-30 r4883 [x86_64-w64-mingw32-w10-1803] (sf-7.0-1)
Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Innodisk 3IE2/3ME2/3MG2/3SE2/3TG6 SSDs
Device Model:     SATA Slim 3TG6-P
Serial Number:    B0011906030460004
LU WWN Device Id: 5 24693e 000000000
Firmware Version: A19926J
User Capacity:    100,030,242,816 bytes [100 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-3 T13/2161-D revision 4
SATA Version is:  SATA 3.0, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Oct 02 11:56:41 2019 
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(    5) seconds.
Offline data collection
capabilities: 			 (0x71) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					No Offline surface scan supported.
					Self-test supported.
					Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (   5) minutes.
Conveyance self-test routine
recommended polling time: 	 (   0) minutes.

SMART Attributes Data Structure revision number: 48
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x0000   100   100   000    Old_age   Offline      -       0
  2 Throughput_Performance  0x0000   100   100   000    Old_age   Offline      -       0
  5 Reallocated_Sector_Ct   0x0012   100   100   000    Old_age   Always       -       0
  7 Unknown_SSD_Attribute   0x0000   100   100   000    Old_age   Offline      -       0
  8 Unknown_SSD_Attribute   0x0000   100   100   000    Old_age   Offline      -       0
  9 Power_On_Hours          0x0012   087   100   000    Old_age   Always       -       87
 10 Unknown_SSD_Attribute   0x0000   100   100   000    Old_age   Offline      -       0
 12 Power_Cycle_Count       0x0012   005   000   000    Old_age   Always       -       5
**163 Total_Bad_Block_Count   0x0012   019   000   000    Old_age   Always       -       19**
165 Max_Erase_Count         0x0012   030   000   000    Old_age   Always       -       30
167 Average_Erase_Count     0x0012   022   000   000    Old_age   Always       -       22
168 Max_Erase_Count_of_Spec 0x0000   100   100   000    Old_age   Offline      -       0
169 Remaining_Lifetime_Perc 0x0000   100   000   000    Old_age   Offline      -       100
**170 Spare_Block_Count       0x0013   100   100   001    Pre-fail  Always       -       780
171 Program_Fail_Count      0x0012   000   100   000    Old_age   Always       -       0
172 Erase_Fail_Count        0x0012   000   100   000    Old_age   Always       -       0**
175 Program_Fail_Count_Chip 0x0012   100   100   000    Old_age   Always       -       0
184 End-to-End_Error        0x0012   000   000   000    Old_age   Always       -       695
187 Reported_Uncorrect      0x0012   000   000   000    Old_age   Always       -       0
192 Power-Off_Retract_Count 0x0012   005   000   000    Old_age   Always       -       5
194 Temperature_Celsius     0x0002   033   100   000    Old_age   Always       -       33 (3 47 0 25 0)
197 Current_Pending_Sector  0x0000   100   100   000    Old_age   Offline      -       0
225 Host_Writes_32MiB       0x0000   100   100   000    Old_age   Offline      -       0
**229 Flash_ID                0x0000   100   100   000    Old_age   Offline      -       125854144806040**
232 Available_Reservd_Space 0x0013   100   100   000    Pre-fail  Always       -       0
**235 Later_Bad_Block_Info    0x0002   000   000   000    Old_age   Always       -       0**
241 Host_Writes_32MiB       0x0012   100   100   000    Old_age   Always       -       160181
242 Host_Reads_32MiB        0x0012   100   100   000    Old_age   Always       -       31
248 Remaining_Life          0x0000   000   000   000    Old_age   Offline      -       100
249 Spare_Blocks_Remaining  0x0012   000   100   000    Old_age   Always       -       100

SMART Error Log Version: 0
No Errors Logged

SMART Self-test log structure revision number 0
Warning: ATA Specification requires self-test log structure revision number = 1
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Selective self-test log data structure revision number 0
Note: revision number not 1 implies that no selective self-test has ever been run
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

