### PR TITLE
Fallback to uname if hostname is not available

### DIFF
--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -605,7 +605,7 @@ AC_SUBST(smartmontools_release_time)
 os_libs=
 os_dltools='curl wget lynx svn'
 os_mailer=mail
-os_hostname="'hostname'"
+os_hostname="'hostname' 'uname -n'"
 os_dnsdomainname=
 os_nisdomainname="'domainname'"
 os_darwin=no


### PR DESCRIPTION
Embedded systems (eg. OpenWRT) might not have the `hostname` command available