### PR TITLE
drivedb.h: Toshiba 2.5" HDD MK..76GSX firmware GS001A

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3517,6 +3517,11 @@ const drive_settings builtin_knowndrives[] = {
     "TOSHIBA MK(32|50|64|75)75GSX",
     "", "", ""
   },
+  { "Toshiba 2.5\" HDD MK..76GSX/GS001A", // tested with TOSHIBA MK2576GSX/GS001A
+    "TOSHIBA MK(16|25|32|50|64)76GSX",
+    "GS001A",
+    "", ""
+  },
   { "Toshiba 2.5\" HDD MK..76GSX", // tested with TOSHIBA MK3276GSX/GS002D
     "TOSHIBA MK(16|25|32|50|64)76GSX",
     "",


### PR DESCRIPTION
I got my hands on an old DELL Latitude E6420
with TOSHIBA MK2576GSX disk (250GB)
smartctl is incorrectly reporting power-on hours as minutes

here are the important excerpts from `smartctl -x` without the patch applied:

```
Model Family:     Toshiba 2.5" HDD MK..76GSX
Device Model:     TOSHIBA MK2576GSX
Serial Number:    51C4C00ET
LU WWN Device Id: 5 000039 343484b90
Firmware Version: GS001A

...

  9 Power_On_Minutes        0x0032   072   072   000    Old_age   Always       -       188h+15m

...

Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%     11295         -
# 2  Extended offline    Completed without error       00%     11225         -
# 3  Short offline       Completed without error       00%     11220         -

```

from `smartctl -B drivedb.h -P showall 'TOSHIBA MK2576GSX' 'GS001A'`:
```
Drive found in smartmontools Database.  Drive identity strings:
MODEL:              TOSHIBA MK2576GSX
FIRMWARE:           GS001A
match smartmontools Drive Database entry:
MODEL REGEXP:       TOSHIBA MK(16|25|32|50|64)76GSX
FIRMWARE REGEXP:    .*
MODEL FAMILY:       Toshiba 2.5" HDD MK..76GSX
ATTRIBUTE OPTIONS:  009 Power_On_Minutes
```

and here with the patch applied:

from `smartctl -B drivedb+patched.h -P showall 'TOSHIBA MK2576GSX' 'GS001A'`
```
Drive found in smartmontools Database.  Drive identity strings:
MODEL:              TOSHIBA MK2576GSX
FIRMWARE:           GS001A
match smartmontools Drive Database entry:
MODEL REGEXP:       TOSHIBA MK(16|25|32|50|64)76GSX
FIRMWARE REGEXP:    GS001A
MODEL FAMILY:       Toshiba 2.5" HDD MK..76GSX/GS001A
ATTRIBUTE OPTIONS:  None preset; no -v options are required.

and match these additional entries:
MODEL REGEXP:       TOSHIBA MK(16|25|32|50|64)76GSX
FIRMWARE REGEXP:    .*
MODEL FAMILY:       Toshiba 2.5" HDD MK..76GSX
ATTRIBUTE OPTIONS:  009 Power_On_Minutes
```

from `smartctl -A -B drivedb+patched.h`
```
  9 Power_On_Hours          0x0032   072   072   000    Old_age   Always       -       11295
```
