### PR TITLE
Fix for bug #65

### DIFF
--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2397,7 +2397,7 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             failuretest(OPTIONAL_CMD,returnval |= FAILSMART);
         } else
             pout("Read cache %sabled\n", (enable ? "en" : "dis"));
-        any_output = true;
+        any_output = true;  
     }
 
     if (options.smart_auto_save_disable) {
@@ -2464,14 +2464,15 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             scsiPrintTemp(device);
 
     // in the 'smartctl -a" case only want: "Accumulated power on time"
+    // Moved so will is process for -a, was running all the time. 
     	if ((! options.smart_background_log) && is_disk) {
             if (! checkedSupportedLogPages)
-             scsiGetSupportedLogPages(device);
-          res = 0;
-            if (gBackgroundResultsLPage)
-          res = scsiPrintBackgroundResults(device, true);
-          any_output = true;
-         }
+                scsiGetSupportedLogPages(device);
+        res = 0;
+        if (gBackgroundResultsLPage)
+              res = scsiPrintBackgroundResults(device, true);
+        any_output = true;
+        }
     }
 
     if (options.smart_vendor_attrib) {

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2338,9 +2338,9 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
                 pout("Writeback Cache is:   %s\n",
                      res ? "Unavailable" : // error
                      !wce ? "Disabled" : "Enabled");
+            any_output = true;
         }
-    } else
-        any_output = true;
+    }
 
     if (options.drive_info)
         pout("\n");
@@ -2462,16 +2462,18 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             scsiGetSupportedLogPages(device);
         if (gTempLPage)
             scsiPrintTemp(device);
-    }
+
     // in the 'smartctl -a" case only want: "Accumulated power on time"
-    if ((! options.smart_background_log) && is_disk) {
-        if (! checkedSupportedLogPages)
-            scsiGetSupportedLogPages(device);
-        res = 0;
-        if (gBackgroundResultsLPage)
-            res = scsiPrintBackgroundResults(device, true);
-        any_output = true;
+    	if ((! options.smart_background_log) && is_disk) {
+            if (! checkedSupportedLogPages)
+             scsiGetSupportedLogPages(device);
+          res = 0;
+            if (gBackgroundResultsLPage)
+          res = scsiPrintBackgroundResults(device, true);
+          any_output = true;
+         }
     }
+
     if (options.smart_vendor_attrib) {
         if (gStartStopLPage)
             scsiGetStartStopData(device);

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2470,7 +2470,7 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
                 scsiGetSupportedLogPages(device);
         res = 0;
         if (gBackgroundResultsLPage)
-              res = scsiPrintBackgroundResults(device, true);
+            res = scsiPrintBackgroundResults(device, true);
         any_output = true;
         }
     }


### PR DESCRIPTION
I have moved the Accumulated power on time to be within the condition of  if (options.smart_vendor_attrib) and running all the time.

Also i noticed another issue with read and write back cache was always setting any_output = true as was part of an else statement, moved into the output processing of the if statement.