### PR TITLE
SCSI  -n option Support

### DIFF
--- a/smartmontools/AUTHORS
+++ b/smartmontools/AUTHORS
@@ -12,6 +12,7 @@ Praveen Chidambaram     <bunchofmails@gmail.com>
 Jonghwan Choi           <jhbird.choi@gmail.com>
 Yuri Dario              <mc6530@mclink.it>
 Casper Dik              <...>
+Simon Fairweather       <simon.n.fairweather@gmail.com>
 Christian Franke        <franke@computer.org>
 Guilhem Frézou          <...>
 Thomas Gatterweh        <thomas_gatterweh@hotmail.com>

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2306,6 +2306,82 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
 
     bool any_output = options.drive_info;
 
+// Enable -n option for SCSI Drives
+
+    const char * powername = 0;
+    bool powerchg = false;
+
+    if (options.powermode) {
+        unsigned char powerlimit = 0xff;
+        scsiRequestSense(device, &sense_info) ;
+        if (sense_info.asc == 94)
+        {
+            int     powermode = sense_info.ascq ;
+
+            // 5Eh/00h  DZTPRO A  K    LOW POWER CONDITION ON
+            // 5Eh/01h  DZTPRO A  K    IDLE CONDITION ACTIVATED BY TIMER
+            // 5Eh/02h  DZTPRO A  K    STANDBY CONDITION ACTIVATED BY TIMER
+            // 5Eh/03h  DZTPRO A  K    IDLE CONDITION ACTIVATED BY COMMAND
+            // 5Eh/04h  DZTPRO A  K    STANDBY CONDITION ACTIVATED BY COMMAND
+            // 5Eh/05h  DZTPRO A  K    IDLE_B CONDITION ACTIVATED BY TIMER
+            // 5Eh/06h  DZTPRO A  K    IDLE_B CONDITION ACTIVATED BY COMMAND
+            // 5Eh/07h  DZTPRO A  K    IDLE_C CONDITION ACTIVATED BY TIMER
+            // 5Eh/08h  DZTPRO A  K    IDLE_C CONDITION ACTIVATED BY COMMAND
+            // 5Eh/09h  DZTPRO A  K    STANDBY_Y CONDITION ACTIVATED BY TIMER
+            // 5Eh/0Ah  DZTPRO A  K    STANDBY_Y CONDITION ACTIVATED BY COMMAND
+            // 5Eh/41h           B     POWER STATE CHANGE TO ACTIVE
+            // 5Eh/42h           B     POWER STATE CHANGE TO IDLE
+            // 5Eh/43h           B     POWER STATE CHANGE TO STANDBY
+            // 5Eh/45h           B     POWER STATE CHANGE TO SLEEP
+            // 5Eh/47h           BK    POWER STATE CHANGE TO DEVICE CONTROL
+
+            switch (powermode) {
+                case -1:
+                   if (device->is_syscall_unsup()) {
+                       pout("CHECK POWER MODE not implemented, ignoring -n option\n"); break;
+                    }
+                powername = "SLEEP";   powerlimit = 2;
+                break;
+
+                case 0x00: // LOW POWER CONDITION ON
+                    powername = "LOW POWER"; powerlimit = 2; break;
+                case 0x01: // IDLE CONDITION ACTIVATED BY TIMER
+                    powername = "IDLE BY TIMER"; powerlimit = 4; break;
+                case 0x02: // STANDBY CONDITION ACTIVATED BY TIMER
+                    powername = "STANDBY BY TIMER";    powerlimit = 2; break;
+                case 0x03: // IDLE CONDITION ACTIVATED BY COMMAND
+                    powername = "IDLE BY COMMAND";  powerlimit = 4; break;
+                case 0x04: // STANDBY CONDITION ACTIVATED BY COMMAND
+                    powername = "STANDBY BY COMMAND";  powerlimit = 2; break;
+                case 0x05: // IDLE_B CONDITION ACTIVATED BY TIMER
+                    powername = "IDLE BY TIMER";  powerlimit = 4; break;
+                case 0x06: // IDLE_B CONDITION ACTIVATED BY COMMAND
+                    powername = "IDLE_ BY COMMAND";  powerlimit = 4; break;
+                case 0x07: // IDLE_C CONDITION ACTIVATED BY TIMER
+                    powername = "IDLE_C BY TIMER";  powerlimit = 4; break;
+                case 0x08: // IDLE_C CONDITION ACTIVATED BY COMMAND
+                    powername = "IDLE_C BY COMMAND";  powerlimit = 4; break;  
+                case 0x09: // STANDBY_Y CONDITION ACTIVATED BY TIMER
+                    powername = "STANDBY_Y BY TIMER";    powerlimit = 2; break;
+                case 0x0A: // STANDBY_Y CONDITION ACTIVATED BY COMMAND
+                    powername = "STANDBY_Y BY COMMAND";  powerlimit = 2; break;
+
+                default:
+                    pout("CHECK POWER MODE returned unknown value 0x%02x, ignoring -n option\n", powermode);
+                    break;
+                }
+            if (powername) {
+                if (options.powermode >= powerlimit) {
+                    jinf("Device is in %s mode, exit(%d)\n", powername, options.powerexit);
+                    return options.powerexit;
+                }
+            powerchg = (powermode != 0xff);
+            }
+        }
+        else powername = "ACTIVE";
+    }
+
+
     if (supported_vpd_pages_p) {
         delete supported_vpd_pages_p;
         supported_vpd_pages_p = NULL;
@@ -2342,8 +2418,11 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
     } else
         any_output = true;
 
-    if (options.drive_info)
+    if (options.drive_info) {
+        if (powername)
+            pout("Power mode %s       %s\n", (powerchg?"was:":"is: "), powername); // Print power condition if requested -n never //
         pout("\n");
+    }
 
     // START OF THE ENABLE/DISABLE SECTION OF THE CODE
     if (options.smart_disable           || options.smart_enable ||
@@ -2592,6 +2671,9 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             return returnval | FAILSMART;
         any_output = true;
     }
+
+    if (!any_output && powername)
+        pout("Device is in %s mode\n", powername); // Output power mode if -n never
 
     if (!any_output)
         pout("SCSI device successfully opened\n\nUse 'smartctl -a' (or '-x') "

--- a/smartmontools/scsiprint.h
+++ b/smartmontools/scsiprint.h
@@ -43,6 +43,9 @@ struct scsi_print_options
   bool get_wce, get_rcd;
   short int set_wce, set_rcd;  // disable(-1), enable(1) cache
 
+  unsigned char powermode; // Enhancement Skip check, if disk in idle or standby mode
+  unsigned char powerexit; // exit() code for low power mode
+
   scsi_print_options()
     : drive_info(false),
       smart_check_status(false),
@@ -60,7 +63,8 @@ struct scsi_print_options
       smart_selftest_force(false),
       sasphy(false), sasphy_reset(false),
       get_wce(false), get_rcd(false),
-      set_wce(0), set_rcd(0)
+      set_wce(0), set_rcd(0) ,
+      powermode(0), powerexit(0) // Power Check -n enhancement option //
     { }
 };
 

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -824,7 +824,7 @@ behaviour.
 This is does not work for SCSI devices yet.
 .TP
 .B \-n POWERMODE[,STATUS], \-\-nocheck=POWERMODE[,STATUS]
-[ATA only] Specifies if \fBsmartctl\fP should exit before performing any
+Specifies if \fBsmartctl\fP should exit before performing any
 checks when the device is in a low-power mode.
 It may be used to prevent a disk from being spun-up by \fBsmartctl\fP.
 The power mode is ignored by default.

--- a/smartmontools/smartctl.cpp
+++ b/smartmontools/smartctl.cpp
@@ -145,7 +145,7 @@ static void Usage()
 "         Set action on bad checksum to one of: warn, exit, ignore\n\n"
 "  -r TYPE, --report=TYPE\n"
 "         Report transactions (see man page)\n\n"
-"  -n MODE[,STATUS], --nocheck=MODE[,STATUS]                           (ATA)\n"
+"  -n MODE[,STATUS], --nocheck=MODE[,STATUS]                           \n"  // Now support for SCSI remove ATA text
 "         No check if: never, sleep, standby, idle (see man page)\n\n",
   getvalidarglist('d').c_str()); // TODO: Use this function also for other options ?
   pout(
@@ -161,7 +161,7 @@ static void Usage()
 "        dsn,[on|off], lookahead,[on|off], security-freeze,\n"
 "        standby,[N|off|now], wcache,[on|off], rcache,[on|off],\n"
 "        wcreorder,[on|off[,p]], wcache-sct,[ata|on|off[,p]]\n\n"
-  );
+  );  
   pout(
 "======================================= READ AND DISPLAY DATA OPTIONS =====\n\n"
 "  -H, --health\n"
@@ -857,9 +857,9 @@ static int parse_options(int argc, char** argv, const char * & type,
       ataopts.smart_selftest_type = ABORT_SELF_TEST;
       break;
     case 'n':
-      // skip disk check if in low-power mode
+      // skip disk check if in low-power mode, now includes SCSI
       if (!strcmp(optarg, "never")) {
-        ataopts.powermode = 1; // do not skip, but print mode
+        ataopts.powermode = scsiopts.powermode = 1; // do not skip, but print mode
       }
       else {
         int n1 = -1, n2 = -1, len = strlen(optarg);
@@ -868,14 +868,14 @@ static int parse_options(int argc, char** argv, const char * & type,
         if (!((n1 == len || n2 == len) && i <= 255))
           badarg = true;
         else if (!strcmp(s, "sleep"))
-          ataopts.powermode = 2;
+          ataopts.powermode = scsiopts.powermode = 2;
         else if (!strcmp(s, "standby"))
-          ataopts.powermode = 3;
+          ataopts.powermode = scsiopts.powermode = 3;
         else if (!strcmp(s, "idle"))
-          ataopts.powermode = 4;
+          ataopts.powermode = scsiopts.powermode = 4;
         else
           badarg = true;
-        ataopts.powerexit = i;
+        ataopts.powerexit = scsiopts.powerexit = i;
       }
       break;
     case 'f':


### PR DESCRIPTION
Added -n function to scsiprint same as ata.

Will print power state for -n never and stop processing if -n standby or idle are specified. Sample output below.

Print will output different power states based  using ASC=5EH and ASCQ.

            // 5Eh/00h  DZTPRO A  K    LOW POWER CONDITION ON
            // 5Eh/01h  DZTPRO A  K    IDLE CONDITION ACTIVATED BY TIMER
            // 5Eh/02h  DZTPRO A  K    STANDBY CONDITION ACTIVATED BY TIMER
            // 5Eh/03h  DZTPRO A  K    IDLE CONDITION ACTIVATED BY COMMAND
            // 5Eh/04h  DZTPRO A  K    STANDBY CONDITION ACTIVATED BY COMMAND
            // 5Eh/05h  DZTPRO A  K    IDLE_B CONDITION ACTIVATED BY TIMER
            // 5Eh/06h  DZTPRO A  K    IDLE_B CONDITION ACTIVATED BY COMMAND
            // 5Eh/07h  DZTPRO A  K    IDLE_C CONDITION ACTIVATED BY TIMER
            // 5Eh/08h  DZTPRO A  K    IDLE_C CONDITION ACTIVATED BY COMMAND
            // 5Eh/09h  DZTPRO A  K    STANDBY_Y CONDITION ACTIVATED BY TIMER
            // 5Eh/0Ah  DZTPRO A  K    STANDBY_Y CONDITION ACTIVATED BY COMMAND
            // 5Eh/41h           B     POWER STATE CHANGE TO ACTIVE
            // 5Eh/42h           B     POWER STATE CHANGE TO IDLE
            // 5Eh/43h           B     POWER STATE CHANGE TO STANDBY
            // 5Eh/45h           B     POWER STATE CHANGE TO SLEEP
            // 5Eh/47h           BK    POWER STATE CHANGE TO DEVICE CONTROL


root@Tower:/usr/local/sbin# smartctl -in standby /dev/sdf
smartctl 7.2 2020-10-09 r5090 [x86_64-linux-5.8.13-Unraid] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

Device is in STANDBY BY TIMER mode, exit(2)
root@Tower:/usr/local/sbin# smartctl -in never /dev/sdf
smartctl 7.2 2020-10-09 r5090 [x86_64-linux-5.8.13-Unraid] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Vendor:               HGST
Product:              HUS724030ALS640
Revision:             A1C4
Compliance:           SPC-4
User Capacity:        3,000,592,982,016 bytes [3.00 TB]
Logical block size:   512 bytes
LU is resource provisioned, LBPRZ=0
Rotation Rate:        7200 rpm
Form Factor:          3.5 inches
Logical Unit id:      0x5000cca0279a0bd0
Serial number:        P8JRR9WW
Device type:          disk
Transport protocol:   SAS (SPL-3)
Local Time is:        Mon Oct 12 13:51:23 2020 BST
SMART support is:     Available - device has SMART capability.
SMART support is:     Enabled
Temperature Warning:  Enabled
Power mode was:       STANDBY BY TIMER
