### PR TITLE
Write attrlog only when new attrs have been read from a disk.

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2020-11-17  Dmitriy Potapov <atomsk+oss@google.com>
+
+	smartd.cpp: Don't write attrlog when device is skipped due to idle or
+	standby mode, or if attributes were not read for any other reason
+	(GH pull/75).
+
 2020-11-09  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Resolve symlinks before device names are checked for


### PR DESCRIPTION
Previously, attrlog values were written uncoditionally every cycle.
If smartd is configured to skip disks in standby mode (-n standby),
it would still write a new attrlog line even if it skips the disk.

This is problematic in two ways.

First, it is writing incorrect data, as the real attribute values
are likely different from the ones that are kept in memory from the
previous cycle.

Second, when attrlog is stored on the same disk, this write will
spin up the disk from power-saving state, thus defeating the
-n standby configuration.

This commit fixes this problem by writing attrlog only when new
attribute values have been actually read from the disk.