### PR TITLE
drivedb.h: Toshiba HK6R Series SSD

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3739,6 +3739,12 @@ const drive_settings builtin_knowndrives[] = {
     "-v 169,raw48,Bad_Block_Count "
     "-v 173,raw48,Erase_Count "
   },
+  { "Toshiba HK6R Series SSD", // TOSHIBA(Kioxia) KHK61RSE3T84
+    // https://business.kioxia.com/content/dam/kioxia/shared/business/ssd/doc/dSSD-Data-Sheet-E-Jun-2020.pdf
+    "TOSHIBA KHK61RSE(1T92|3T84)",
+    "", "",
+    "-v 173,raw48,Erase_Count "
+  },
   { "Toshiba HG6 Series SSD", // TOSHIBA THNSNJ512GCST/JTRA0102
     // http://www.farnell.com/datasheets/1852757.pdf
     // TOSHIBA THNSFJ256GCSU/JULA1102


### PR DESCRIPTION
add [Toshiba(Kioxia) HK6R SSD](https://business.kioxia.com/en-us/ssd/data-center-ssd/hk6-r.html) to drivedb.h

my `smartctl -q noserial -x` output is below.

```
smartctl 7.0 2018-12-30 r4883 [x86_64-linux-5.3.13-1-pve] (local build)
Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     TOSHIBA KHK61RSE3T84
Firmware Version: 1DET6101
User Capacity:    3,840,755,982,336 bytes [3.84 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Fri Feb 19 12:31:23 2021 JST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM level is:     254 (maximum performance)
Rd look-ahead is: Enabled
Write cache is:   Disabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, NOT FROZEN [SEC1]
Write SCT (Get) Feature Control Command failed: ATA return descriptor not supported by controller firmware
Wt Cache Reorder: Unknown (SCT Feature Control command failed)

=== START OF READ SMART DATA SECTION ===
SMART Status not supported: ATA return descriptor not supported by controller firmware
SMART overall-health self-assessment test result: PASSED
Warning: This result is based on an Attribute check.

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x59) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   1) minutes.
Extended self-test routine
recommended polling time: 	 (   5) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 4258
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  5 Reallocated_Sector_Ct   PO--C-   100   100   010    -    0
  9 Power_On_Hours          -O--C-   100   100   000    -    10148
 12 Power_Cycle_Count       -O--CK   100   100   000    -    10
173 Unknown_Attribute       -O--C-   200   200   000    -    0
175 Program_Fail_Count_Chip PO--CK   100   100   099    -    1859720839168
179 Used_Rsvd_Blk_Cnt_Tot   PO--C-   100   100   010    -    0
181 Program_Fail_Cnt_Total  -O--CK   100   100   000    -    0
182 Erase_Fail_Count_Total  -O--CK   100   100   000    -    0
183 Runtime_Bad_Block       -O--CK   100   100   000    -    0
184 End-to-End_Error        PO--CK   100   100   090    -    0
187 Reported_Uncorrect      -O--CK   100   100   000    -    0
190 Airflow_Temperature_Cel -O---K   074   068   000    -    26 (Min/Max 16/32)
192 Power-Off_Retract_Count -O--CK   100   100   000    -    8
194 Temperature_Celsius     -O---K   071   065   000    -    29 (Min/Max 19/35)
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    -O-R--   100   100   000    -    0
232 Available_Reservd_Space PO--C-   100   100   010    -    0
233 Media_Wearout_Indicator -O--C-   100   100   000    -    0
234 Unknown_Attribute       -O--CK   100   100   000    -    97792
241 Total_LBAs_Written      -O--CK   100   100   000    -    1023081
242 Total_LBAs_Read         -O--CK   100   100   000    -    2436234
243 Unknown_Attribute       -O--C-   100   100   000    -    0
249 Unknown_Attribute       -O--CK   100   100   000    -    91218
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O     51  Comprehensive SMART error log
0x03       GPL     R/O     64  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O     16  Extended self-test log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x13       GPL     R/O      1  SATA NCQ Send and Receive log
0x24       GPL     R/O   8191  Current Device Internal Status Data log
0x25       GPL     R/O      1  Saved Device Internal Status Data log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (64 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (16 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%     10148         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       3 (0x0003)
Device State:                        Active (0)
Current Temperature:                    29 Celsius
Power Cycle Min/Max Temperature:     19/35 Celsius
Lifetime    Min/Max Temperature:     19/35 Celsius
Under/Over Temperature Limit Count:   0/0
Vendor specific:
00 00 04 00 01 01 00 05 05 00 00 00 00 00 00 00
00 00 00 00 9f 7a 2d 02 1c 00 00 00 00 00 00 10

Write SCT Data Table failed: SMART WRITE LOG SECTOR may cause problems, try with -T permissive to force
Read SCT Temperature History failed

Write SCT (Get) Error Recovery Control Command failed: ATA return descriptor not supported by controller firmware
SCT (Get) Error Recovery Control command failed

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4              10  ---  Lifetime Power-On Resets
0x01  0x010  4           10148  ---  Power-on Hours
0x01  0x018  6     67048700687  ---  Logical Sectors Written
0x01  0x020  6       398650439  ---  Number of Write Commands
0x01  0x028  6    159661063638  ---  Logical Sectors Read
0x01  0x030  6       668656885  ---  Number of Read Commands
0x01  0x038  6     36534622000  ---  Date and Time TimeStamp
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               0  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              29  ---  Current Temperature
0x05  0x010  1              29  ---  Average Short Term Temperature
0x05  0x018  1              29  ---  Average Long Term Temperature
0x05  0x020  1              35  ---  Highest Temperature
0x05  0x028  1              19  ---  Lowest Temperature
0x05  0x030  1              33  ---  Highest Average Short Term Temperature
0x05  0x038  1              22  ---  Lowest Average Short Term Temperature
0x05  0x040  1              33  ---  Highest Average Long Term Temperature
0x05  0x048  1              33  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              70  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4               3  ---  Number of Hardware Resets
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  N--  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  8            0  Command failed due to ICRC error
0x0002  8            0  R_ERR response for data FIS
0x0003  8            0  R_ERR response for device-to-host data FIS
0x0004  8            0  R_ERR response for host-to-device data FIS
0x0005  8            0  R_ERR response for non-data FIS
0x0006  8            0  R_ERR response for device-to-host non-data FIS
0x0007  8            0  R_ERR response for host-to-device non-data FIS
0x000a  8            3  Device-to-host register FISes sent due to a COMRESET
0x000b  8            0  CRC errors within host-to-device FIS
0x000d  8            0  Non-CRC errors within host-to-device FIS
```

and,  pubric data of `KHK61RSE1T92` is https://github.com/linuxhw/SMART/tree/master/SSD/Toshiba/KHK61/KHK61RSE1T92