### PR TITLE
drivedb.h: Add Advantech SQFlash 630 series support

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -828,6 +828,31 @@ const drive_settings builtin_knowndrives[] = {
     "-v 245,raw48,Max_Erase_Count "
     "-v 246,raw48,Total_Erase_Count "
   },
+  { "Advantech SQFlash 630 series", // see https://advdownload.advantech.com/productfile/PIS/SQF-S25%20630/Product%20-%20Datasheet/SQF-S25%20630_830_DS(02.22.16)20160317192116.pdf
+    "SQF-S25[SUM][24]-(8|16|32|64|128)G-S9[CE]", // tested with SQF-S25M4-64G-S9C/S9FMA028
+    "", "", // attributes info from https://advdownload.advantech.com/productfile/Downloadfile5/1-1YC6U6K/SQFlash SMART ID Definition(SATA)_20200115.pdf
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 14,raw48,Device_Capacity_LBAs "
+    "-v 15,raw48,User_Capacity_LBAs "
+    "-v 16,raw48,Init_Spare_Blocks_Avail "
+    "-v 17,raw48,Spare_Blocks_Remaining "
+    "-v 100,raw48,Total_Erase_Count "
+    "-v 168,raw48,SATA_Phy_Error_Count "
+    "-v 170,raw24/raw24:z54z10,Bad_Blk_Ct_Erl/Lat " // Early bad block/Later bad block
+    "-v 173,raw16(avg16),MaxAvgErase_Ct "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 175,raw48,PwrLoss_ProtectionFail "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 194,raw48,Unknown_Attribute " // 630 series doesn’t have a temperature sensor and reports fix 30 degrees C
+    "-v 218,raw48,CRC_Error_Count "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 234,raw48,Total_NAND_Read "
+    "-v 235,raw48,Total_NAND_Written "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+  },
   { "Indilinx Barefoot based SSDs",
     "Corsair CSSD-V(32|60|64|128|256)GB2|" // Corsair Nova, tested with Corsair CSSD-V32GB2/2.2
     "Corsair CMFSSD-(32|64|128|256)D1|" // Corsair Extreme, tested with Corsair CMFSSD-128D1/1.0


### PR DESCRIPTION
Add [Advantech SQFlash 630 series](https://www.advantech.com/products/c092ee32-e070-4609-8020-d3fff67719f0/sqf-s25-630/mod_f684b355-fa28-4ab9-bc0d-b494f129f845) to drivedb.h

my `smartctl -q noserial -x` output is below.

```
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.4.128] (localbuild)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Advantech SQFlash 630 series
Device Model:     SQF-S25M4-64G-S9C
Firmware Version: S9FMA028
User Capacity:    64,023,257,088 bytes [64.0 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Thu Jul  1 13:01:38 2021 CEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Disabled
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]
Wt Cache Reorder: Unavailable

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever 
                                        been run.
Total time to complete Offline 
data collection:                (   30) seconds.
Offline data collection
capabilities:                    (0x1b) SMART execute Offline immediate.
                                        Auto Offline data collection on/off support.
                                        Suspend Offline collection upon new
                                        command.
                                        Offline surface scan supported.
                                        Self-test supported.
                                        No Conveyance Self-test supported.
                                        No Selective Self-test supported.
SMART capabilities:            (0x0003) Saves SMART data before entering
                                        power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine 
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        (  44) minutes.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     -O-R--   100   100   050    -    0
  9 Power_On_Hours          -O--C-   100   100   000    -    5466
 12 Power_Cycle_Count       -O--C-   100   100   000    -    95
 14 Device_Capacity_LBAs    -O--C-   100   100   000    -    138018816
 15 User_Capacity_LBAs      -O--C-   100   100   000    -    125045424
 16 Init_Spare_Blocks_Avail -O--C-   100   100   000    -    93
 17 Spare_Blocks_Remaining  -O--C-   100   100   000    -    77
100 Total_Erase_Count       -O--C-   100   100   000    -    10926
168 SATA_Phy_Error_Count    -O--C-   100   100   000    -    0
170 Bad_Blk_Ct_Erl/Lat      PO----   082   082   010    -    0/74
173 MaxAvgErase_Ct          -O--C-   100   100   000    -    94 (Average 1)
174 Unexpect_Power_Loss_Ct  -O--C-   100   100   000    -    1
192 Unsafe_Shutdown_Count   -O--C-   100   100   000    -    1
194 Unknown_Attribute       PO---K   070   070   000    -    30
218 CRC_Error_Count         PO-R--   100   100   050    -    0
231 SSD_Life_Left           PO--C-   100   100   000    -    99
234 Total_NAND_Read         PO-R--   100   100   000    -    5305
235 Total_NAND_Written      PO-R--   100   100   000    -    44047
241 Total_LBAs_Written      -O--CK   000   000   000    -    17519
242 Total_LBAs_Read         -O--C-   100   100   000    -    5305
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O     51  Comprehensive SMART error log
0x03       GPL     R/O     64  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log

SMART Extended Comprehensive Error Log Version: 1 (64 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

Selective Self-tests/Logging not supported

SCT Commands not supported

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            0  Command failed due to ICRC error
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
0x0008  2            0  Device-to-host non-data FIS retries
0x0009  4           14  Transition from drive PhyRdy to drive PhyNRdy
0x000a  4           15  Device-to-host register FISes sent due to a COMRESET
0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC
```