### PR TITLE
drivedb.h: Samsung Portable SSD T7

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -5140,6 +5140,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  { "USB: Samsung Portable SSD T7; ",
+    "0x04e8:0x4001",
+    "",
+    "",
+    "-d sntasmedia"
+  },
   { "USB: Samsung; ",
     "0x04e8:0x8003", // USB3 Adapter from SSD EVO 850 Starter Kit
     "", // 0x0100


### PR DESCRIPTION
Related ticket: https://www.smartmontools.org/ticket/1403

`-x -q noserial` on this device (with change to drivedb.h):

```
smartctl 7.3 2021-06-26 r5227 [x86_64-linux-5.4.0-77-generic] (CircleCI)
Copyright (C) 2002-21, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       Samsung Portable SSD T7
Firmware Version:                   FXG42P2Q
PCI Vendor/Subsystem ID:            0x144d
IEEE OUI Identifier:                0x002538
Total NVM Capacity:                 500,107,862,016 [500 GB]
Unallocated NVM Capacity:           0
Controller ID:                      5
NVMe Version:                       1.3
Number of Namespaces:               1
Namespace 1 Size/Capacity:          500,107,862,016 [500 GB]
Namespace 1 Utilization:            67,162,112 [67.1 MB]
Namespace 1 Formatted LBA Size:     512
Local Time is:                      Thu Jul 22 17:03:13 2021 CEST
Firmware Updates (0x16):            3 Slots, no Reset required
Optional Admin Commands (0x0007):   Security Format Frmw_DL
Optional NVM Commands (0x001f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat
Log Page Attributes (0x03):         S/H_per_NS Cmd_Eff_Lg
Maximum Data Transfer Size:         512 Pages
Warning  Comp. Temp. Threshold:     49 Celsius
Critical Comp. Temp. Threshold:     53 Celsius

Supported Power States
St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
 0 +     4.83W       -        -    0  0  0  0        0       0
 1 +     3.54W       -        -    1  1  1  1        0       0
 2 +     3.04W       -        -    2  2  2  2        0       0
 3 -   0.0500W       -        -    3  3  3  3    26000    1000

Supported LBA Sizes (NSID 0x1)
Id Fmt  Data  Metadt  Rel_Perf
 0 +     512       0         0

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02)
Critical Warning:                   0x00
Temperature:                        29 Celsius
Available Spare:                    100%
Available Spare Threshold:          10%
Percentage Used:                    0%
Data Units Read:                    17 [8.70 MB]
Data Units Written:                 0
Host Read Commands:                 337
Host Write Commands:                0
Controller Busy Time:               0
Power Cycles:                       8
Power On Hours:                     1
Unsafe Shutdowns:                   7
Media and Data Integrity Errors:    0
Error Information Log Entries:      0
Warning  Comp. Temperature Time:    0
Critical Comp. Temperature Time:    0
Temperature Sensor 1:               29 Celsius
Temperature Sensor 2:               28 Celsius

Warning: NVMe Get Log truncated to 0x200 bytes, 0x200 bytes zero filled
Error Information (NVMe Log 0x01, 16 of 64 entries)
No Errors Logged
```