### PR TITLE
add Hynix SC311 to drivedb

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -2818,7 +2818,8 @@ const drive_settings builtin_knowndrives[] = {
       // HFS512G32MND-3210A/20100P00, HFS512G39MND-3310A/20002P00
     "HFS(120|250|500)G32TND-N1A2A|" // SL308, tested with HFS500G32TND-N1A2A/30000P10
     "HFS(128|256|512)G39MND-3510A|" // SC300, tested with HFS512G39MND-3510A/20400P00
-    "HFS(128|256|512)G39TND-N210A", // SC308, tested with HFS128G39TND-N210A/30001P10
+    "HFS(128|256|512)G39TND-N210A|" // SC308, tested with HFS128G39TND-N210A/30001P10
+    "HFS(128|256|512)G32TNF-N3A0A", // SC311, tested with HFS128G32TNF-N3A0A/70000P10
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
     "-v 5,raw48,Retired_Block_Count "
@@ -2853,9 +2854,11 @@ const drive_settings builtin_knowndrives[] = {
     "-v 212,raw48,Phy_Error_Count "
     "-v 231,raw48,SSD_Life_Left "
     "-v 234,raw48,Unknown_SK_hynix_Attrib "
+    "-v 236,raw48,Unknown_SK_hynix_Attrib "
     "-v 241,raw48,Total_Writes_GiB "
     "-v 242,raw48,Total_Reads_GiB "
     "-v 243,raw48,Total_Media_Writes "
+    "-v 249,raw48,NAND_Writes_GiB "
     "-v 250,raw48,Read_Retry_Count "
   },
   { "SK hynix SATA SSDs",


### PR DESCRIPTION
Hello there!

I have a not yet added SC311 drive from Hynix, which I'd like to add to the database.
They introduced two new attributes, 249 is very obvious, however 236 seems very general to me.
Thanks

Here is the output:

`# ./smartctl -a /dev/sda
smartctl 7.3 (build date Sep  4 2021) [x86_64-linux-5.10.55-1-lts] (local build)
Copyright (C) 2002-21, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     SK hynix SATA SSDs
Device Model:     HFS128G32TNF-N3A0A
Serial Number:    ****************
Firmware Version: 70000P10
User Capacity:    128.035.676.160 bytes [128 GB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Sat Sep  4 07:16:02 2021 CEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x02)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(  110) seconds.
Offline data collection
capabilities: 			 (0x51) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					No Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0002)	Does not save SMART data before
					entering power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  20) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 0
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000f   166   166   006    Pre-fail  Always       -       0
  5 Retired_Block_Count     0x0032   253   253   036    Old_age   Always       -       0
  9 Power_On_Hours          0x0032   099   099   000    Old_age   Always       -       1072
 12 Power_Cycle_Count       0x0032   100   100   020    Old_age   Always       -       921
100 Total_Erase_Count       0x0032   100   100   000    Old_age   Always       -       353392
168 Min_Erase_Count         0x0032   100   100   000    Old_age   Always       -       7
169 Max_Erase_Count         0x0032   097   097   000    Old_age   Always       -       58
171 Program_Fail_Count      0x0032   253   253   000    Old_age   Always       -       0
172 Erase_Fail_Count        0x0032   253   253   000    Old_age   Always       -       0
173 Wear_Leveling_Count     0x0032   099   099   000    Old_age   Always       -       25
174 Unexpect_Power_Loss_Ct  0x0030   100   100   000    Old_age   Offline      -       66
175 Program_Fail_Count_Chip 0x0032   253   253   000    Old_age   Always       -       0
176 Unused_Rsvd_Blk_Cnt_Tot 0x0032   253   253   000    Old_age   Always       -       0
178 Used_Rsvd_Blk_Cnt_Chip  0x0032   253   253   000    Old_age   Always       -       0
179 Used_Rsvd_Blk_Cnt_Tot   0x0032   253   253   000    Old_age   Always       -       0
180 Erase_Fail_Count        0x0033   100   100   010    Pre-fail  Always       -       100
184 End-to-End_Error        0x0032   253   253   000    Old_age   Always       -       0
187 Reported_Uncorrect      0x0032   253   253   000    Old_age   Always       -       0
188 Command_Timeout         0x0032   253   253   000    Old_age   Always       -       0
194 Temperature_Celsius     0x0002   026   014   000    Old_age   Always       -       26 (Min/Max 14/45)
195 Hardware_ECC_Recovered  0x0032   253   253   000    Old_age   Always       -       0
196 Reallocated_Event_Count 0x0032   253   253   036    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0032   253   253   000    Old_age   Always       -       0
199 UDMA_CRC_Error_Count    0x0032   253   253   000    Old_age   Always       -       0
212 Phy_Error_Count         0x0032   100   100   000    Old_age   Always       -       3068
233 Media_Wearout_Indicator 0x0033   099   099   001    Pre-fail  Always       -       99
236 Unknown_SK_hynix_Attrib 0x0032   095   095   001    Old_age   Always       -       95
241 Total_Writes_GiB        0x0032   100   100   000    Old_age   Always       -       3609
242 Total_Reads_GiB         0x0032   100   100   000    Old_age   Always       -       4420
249 NAND_Writes_GiB         0x0032   100   100   000    Old_age   Always       -       3170

SMART Error Log Version: 0
No Errors Logged

SMART Self-test log structure revision number 1
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%       164         -

Warning! SMART Selective Self-Test Log Structure error: invalid SMART checksum.
SMART Selective self-test log data structure revision number 0
Note: revision number not 1 implies that no selective self-test has ever been run
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.`