### PR TITLE
[smartctl] consistent Serial Number string

### DIFF
--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2104,7 +2104,7 @@ scsiGetDriveInfo(scsi_device * device, uint8_t * peripheral_type, bool all)
 
             gBuf[4 + len] = '\0';
             scsi_format_id_string(serial, &gBuf[4], len);
-            jout("Serial number:        %s\n", serial);
+            jout("Serial Number:        %s\n", serial);
             jglb["serial_number"] = serial;
         } else if (scsi_debugmode > 0) {
             print_on();


### PR DESCRIPTION
The ``Serial Number`` string is not consistent for SCSI devices:
```
nvmeprint.cpp
115:    jout("Serial Number:                      %s\n", format_char_array(buf, id_ctrl.sn));
ataprint.cpp
656:    jout("Serial Number:    %s\n", infofound(serial));
scsiprint.cpp
2107:   jout("Serial number:        %s\n", serial);
```
This PR makes it easier for wrapper scripts to parse this data.

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>