### PR TITLE
dev_interface.cpp: Retry on UNIT ATTENTION when fetching capacity

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2021-11-08  Yannick Hemery  <yannick.hemery@corp.ovh.com>
+
+	scsicmds.cpp: Retry on UNIT ATTENTION when fetching capacity (#1303).
+
+	If a UNIT ATTENTION is raised when READ CAPACITY (16) is called,
+	smartctl might wrongly assume that the drive only supports READ
+	CAPACITY (10), and return an invalid drive size / block size as a result.
+
 2021-11-06  Christian Franke  <franke@computer.org>
 
 	update-smart-drivedb.in: Add '-q' option to suppress info messages.

--- a/smartmontools/scsicmds.h
+++ b/smartmontools/scsicmds.h
@@ -440,6 +440,8 @@ int scsiSetPowerCondition(scsi_device * device, int power_cond,
 int scsiSendDiagnostic(scsi_device * device, int functioncode, uint8_t *pBuf,
                        int bufLen);
 
+bool scsi_pass_through_with_retry(scsi_device * device, scsi_cmnd_io * iop);
+
 int scsiReadDefect10(scsi_device * device, int req_plist, int req_glist,
                      int dl_format, uint8_t *pBuf, int bufLen);
 


### PR DESCRIPTION
Proposal for [#1303](https://www.smartmontools.org/ticket/1303)

Prior to the patch, the wrong capacity / block size might be returned if a UNIT ATTENTION is raised:

```
root@rescue:~# sg_reset -d /dev/sg2
root@rescue:~# smartctl -i /dev/sg2 | grep -iP 'size|capaci'
User Capacity:        2,199,023,255,552 bytes [2.19 TB]
Logical block size:   512 bytes
```
With the patch:
```
root@rescue:~# sg_reset -d /dev/sg2
root@rescue:~# smartctl -i /dev/sg2 | grep -iP 'size|capaci'
User Capacity:        3,840,755,982,336 bytes [3.84 TB]
Logical block size:   512 bytes
Physical block size:  4096 bytes
```