### PR TITLE
WIP: MFI Raid support on the FreeBSD

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2021-11-22  Alex Samorukov <samm@os2.kiev.ua>
+
+	os_freebsd.cpp: initial support of the direct MegaRaid access using 
+	'-d megaraid' option. Code is initially based on Linux version but adopted to
+	be compatible with FreeBSD IOCTL-s.
+
 2021-11-13  Christian Franke  <franke@computer.org>
 
 	smartctl.8.in, smartd.8.in: Remove EXPERIMENTAL notes for features

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,7 +2,7 @@ $Id$
 
 2021-11-22  Alex Samorukov <samm@os2.kiev.ua>
 
-	os_freebsd.cpp: initial support of the direct MegaRaid access using 
+	os_freebsd.cpp: initial support of the direct MegaRaid access using
 	'-d megaraid' option. Code is initially based on Linux version but adopted to
 	be compatible with FreeBSD IOCTL-s.
 

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -39,7 +39,7 @@ Summary: smartmontools release 7.3
 - OpenBSD: Fixed too short command timeouts.
 - OpenBSD: Fixed device name used for autodetection.
 - OpenBSD: Fixed SAT autodetection of sd* devices.
-- FreeBSD: Added direct access ('-d megaraid,N') and scanning for LSI RAID on 
+- FreeBSD: Added direct access ('-d megaraid,N') and scanning for LSI RAID on
   'mfi' and 'mrsas' controllers.
 - Windows: Disabled '-d aacraid' support due to unresolved bugs.
   Added '-d accraid,...,force' flag to try anyway.

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -39,6 +39,8 @@ Summary: smartmontools release 7.3
 - OpenBSD: Fixed too short command timeouts.
 - OpenBSD: Fixed device name used for autodetection.
 - OpenBSD: Fixed SAT autodetection of sd* devices.
+- FreeBSD: Added direct access ('-d megaraid,N') and scanning for LSI RAID on 
+  'mfi' and 'mrsas' controllers.
 - Windows: Disabled '-d aacraid' support due to unresolved bugs.
   Added '-d accraid,...,force' flag to try anyway.
 

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -26,14 +26,12 @@
 #endif
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sys/uio.h>
 #include <glob.h>
 #include <stddef.h>
 #include <paths.h>
 #include <sys/utsname.h>
  
-#include <sys/types.h>
-#include <sys/uio.h>
-
 #include "config.h"
 
 // set by /usr/include/sys/ata.h, suppress warning

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -2267,7 +2267,7 @@ smart_device * freebsd_smart_interface::autodetect_smart_device(const char * nam
   }
   // device is LSI raid supported by mfi driver
   if(!strncmp("/dev/mfid", test_name, strlen("/dev/mfid")))
-    set_err(EINVAL, "To monitor disks on LSI RAID load mfip.ko module and run 'smartctl -a /dev/passX' to show SMART information");
+    set_err(EINVAL, "To monitor disks on LSI RAID load mfip.ko and use /dev/passX or use -d 'megaraid,N' with /dev/mfiX devices");
 
   // form /dev/nvme* or nvme*
   if(!strncmp("/dev/nvme", test_name, strlen("/dev/nvme")))

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -200,6 +200,9 @@ static const char  smartctl_examples[] =
   "  smartctl -a --device=areca,3/1 /dev/arcmsr0\n"
          "                              (Prints all SMART information for 3rd disk in the 1st enclosure \n"
          "                               on first ARECA RAID controller)\n"
+  "  smartctl -a --device=megaraid,3 /dev/mrsas0\n"
+         "                              (Prints all SMART information for 3rd disk\n"
+         "                               on first LSI RAID controller)\n"
 
          ;
 

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -971,7 +971,7 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
     
     pthru->header.sg_count = 1;
     pthru->header.data_len = dataLen;
-    // tested on amd64 in native and 32bit mode
+    // tested on amd64 kernel in native and 32bit mode
     pthru->sgl.sg64[0].addr = (intptr_t)data;
     pthru->sgl.sg64[0].len = (uint32_t)dataLen;
   }

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -853,18 +853,7 @@ smart_device * freebsd_megaraid_device::autodetect_open()
 
 bool freebsd_megaraid_device::open()
 {
-  int   mjr;
-  int report = scsi_debugmode;
-
-  if (sscanf(get_dev_name(), "/dev/bus/%u", &m_hba) == 0) {
-    if (!freebsd_smart_device::open())
-      return false;
-    // we don't need this device anymore
-    freebsd_smart_device::close();
-  }
- 
   /* Open Device IOCTL node */
-  // FIXME
   if ((m_fd = ::open(get_dev_name(), O_RDWR)) >= 0) {
     pt_cmd = &freebsd_megaraid_device::megasas_cmd;
   }

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -971,7 +971,7 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
     uio.mfi_sgl_off = offsetof(struct mfi_pass_frame,sgl);
     uio.mfi_sgl[0].iov_base = data;
     uio.mfi_sgl[0].iov_len = dataLen;
-  
+
     pthru->header.sg_count = 1;
     pthru->header.data_len = dataLen;
     // tested on amd64 kernel in native and 32bit mode

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -985,7 +985,6 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
       pthru->header.flags =  MFI_FRAME_DIR_NONE;
       break;
   }
-pthru->header.flags |= MFI_FRAME_SGL64;
 
   if (dataLen > 0) {
     pthru->header.sg_count = 1;

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -1632,6 +1632,15 @@ smart_device * freebsd_scsi_device::autodetect_open()
                     "you may need to replace %s with /dev/twaN, /dev/tweN or /dev/twsN", get_dev_name());
     return this;
   }
+  
+  // DELL?
+  if (!memcmp(req_buff + 8, "DELL    PERC", 12) || !memcmp(req_buff + 8, "MegaRAID", 8)
+      || !memcmp(req_buff + 16, "PERC H", 6) || !memcmp(req_buff + 8, "LSI\0",4)
+  ) {
+    close();
+    set_err(EINVAL, "DELL or MegaRaid controller, use '-d megaraid,N'");
+    return this;
+  }
 
   // SAT or USB, skip MFI controllers because of bugs
   {

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -2045,7 +2045,7 @@ bool freebsd_smart_interface::get_dev_megaraid(smart_device_list & devlist)
   /* Scanning of disks on MegaRaid device */
   char ctrlpath[64];
 
-  // trying to add devices on first 32 buses, same as storclu does
+  // trying to add devices on first 32 buses, same as StorCLI does
   for(unsigned i = 0; i <=32; i++) {
       sprintf(ctrlpath, "%s%d", MFI_CTRLR_PREFIX, i);
       megaraid_pd_add_list(ctrlpath, devlist);

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -34,9 +34,6 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 
-#include "mfireg.h"
-#include "mfi_ioctl.h"
-
 #include "config.h"
 
 // set by /usr/include/sys/ata.h, suppress warning
@@ -793,11 +790,9 @@ private:
   int m_fd;
 
   bool (freebsd_megaraid_device::*pt_cmd)(int cdblen, void *cdb, int dataLen, void *data,
-    int senseLen, void *sense, int report, int direction);
+    int senseLen, void *sense, int report, int direction, int timeout);
   bool megasas_cmd(int cdbLen, void *cdb, int dataLen, void *data,
-    int senseLen, void *sense, int report, int direction);
-  bool megadev_cmd(int cdbLen, void *cdb, int dataLen, void *data,
-    int senseLen, void *sense, int report, int direction);
+    int senseLen, void *sense, int report, int direction, int timeout);
 };
 
 freebsd_megaraid_device::freebsd_megaraid_device(smart_interface *intf,

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -971,7 +971,7 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
     uio.mfi_sgl_off = offsetof(struct mfi_pass_frame,sgl);
     uio.mfi_sgl[0].iov_base = data;
     uio.mfi_sgl[0].iov_len = dataLen;
-    
+  
     pthru->header.sg_count = 1;
     pthru->header.data_len = dataLen;
     // tested on amd64 kernel in native and 32bit mode

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -958,7 +958,6 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
   struct mfi_ioc_packet uio;
   
   pthru = (struct mfi_pass_frame *)&uio.mfi_frame.raw;
-
   memset(&uio, 0, sizeof(uio));
   
   pthru->header.cmd = MFI_CMD_PD_SCSI_IO;
@@ -987,6 +986,11 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
   }
 
   if (dataLen > 0) {
+    uio.mfi_sge_count = 1;
+    uio.mfi_sgl_off = offsetof(struct mfi_pass_frame,sgl);
+    uio.mfi_sgl[0].iov_base = data;
+    uio.mfi_sgl[0].iov_len = dataLen;
+    
     pthru->header.sg_count = 1;
     pthru->header.data_len = dataLen;
     pthru->sgl.sg64[0].addr = (intptr_t)data;
@@ -1000,15 +1004,6 @@ bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
   uio.mfi_adapter_no = m_hba;
   uio.mfi_sense_len = senseLen;
   uio.mfi_sense_off = offsetof(struct mfi_pass_frame, sense_addr_lo);
-
-//  printf("sizeof=%d\n",sizeof( mfi_ioc_packet));
-
-  if (dataLen > 0) {
-    uio.mfi_sge_count = 1;
-    uio.mfi_sgl_off = offsetof(struct mfi_pass_frame,sgl); // 0x30;//offsetof(struct mfi_ioc_packet, mfi_sgl);
-    uio.mfi_sgl[0].iov_base = data;
-    uio.mfi_sgl[0].iov_len = dataLen;
-  }
 
   errno = 0;
   // fixme add 32 bit code

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -773,7 +773,7 @@ class freebsd_megaraid_device
   public /* extends */ freebsd_smart_device
 {
 public:
-  freebsd_megaraid_device(smart_interface *intf, const char *name, 
+  freebsd_megaraid_device(smart_interface *intf, const char *name,
     unsigned int tgt);
 
   virtual ~freebsd_megaraid_device();
@@ -911,7 +911,7 @@ bool freebsd_megaraid_device::scsi_pass_through(scsi_cmnd_io *iop)
   if (iop->cmnd[0] == 0x00)
     return true;
 
-  if (iop->cmnd[0] == SAT_ATA_PASSTHROUGH_12 || iop->cmnd[0] == SAT_ATA_PASSTHROUGH_16) { 
+  if (iop->cmnd[0] == SAT_ATA_PASSTHROUGH_12 || iop->cmnd[0] == SAT_ATA_PASSTHROUGH_16) {
     // Controller does not return ATA output registers in SAT sense data
     if (iop->cmnd[2] & (1 << 5)) // chk_cond
       return set_err(ENOSYS, "ATA return descriptor not supported by controller firmware");
@@ -920,10 +920,10 @@ bool freebsd_megaraid_device::scsi_pass_through(scsi_cmnd_io *iop)
   if ((iop->cmnd[0] == SAT_ATA_PASSTHROUGH_16 // SAT16 WRITE LOG
       && iop->cmnd[14] == ATA_SMART_CMD && iop->cmnd[3]==0 && iop->cmnd[4] == ATA_SMART_WRITE_LOG_SECTOR) ||
       (iop->cmnd[0] == SAT_ATA_PASSTHROUGH_12 // SAT12 WRITE LOG
-       && iop->cmnd[9] == ATA_SMART_CMD && iop->cmnd[3] == ATA_SMART_WRITE_LOG_SECTOR)) 
+       && iop->cmnd[9] == ATA_SMART_CMD && iop->cmnd[3] == ATA_SMART_WRITE_LOG_SECTOR))
   {
     if(!failuretest_permissive)
-       return set_err(ENOSYS, "SMART WRITE LOG SECTOR may cause problems, try with -T permissive to force"); 
+       return set_err(ENOSYS, "SMART WRITE LOG SECTOR may cause problems, try with -T permissive to force");
   }
   if (pt_cmd == NULL)
     return false;
@@ -932,22 +932,22 @@ bool freebsd_megaraid_device::scsi_pass_through(scsi_cmnd_io *iop)
     iop->max_sense_len, iop->sensep, report, iop->dxfer_dir, iop->timeout);
 }
 
-bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb, 
+bool freebsd_megaraid_device::megasas_cmd(int cdbLen, void *cdb,
   int dataLen, void *data,
   int senseLen, void * sense, int /*report*/, int dxfer_dir, int timeout)
 {
   struct mfi_pass_frame * pthru;
   struct mfi_ioc_packet uio;
-  
+
   pthru = (struct mfi_pass_frame *)&uio.mfi_frame.raw;
   memset(&uio, 0, sizeof(uio));
-  
+
   pthru->header.cmd = MFI_CMD_PD_SCSI_IO;
   pthru->header.cmd_status = 0;
   pthru->header.scsi_status = 0x0;
   pthru->header.target_id = m_disknum;
   pthru->header.lun_id = 0; // FIXME, should be bus number?
-  
+
   pthru->header.sense_len = senseLen;
   pthru->sense_addr_lo = (uintptr_t)sense ;
   pthru->sense_addr_hi = (uintptr_t)((uint64_t)sense >> 32);
@@ -1635,7 +1635,7 @@ smart_device * freebsd_scsi_device::autodetect_open()
                     "you may need to replace %s with /dev/twaN, /dev/tweN or /dev/twsN", get_dev_name());
     return this;
   }
-  
+
   // DELL?
   if (!memcmp(req_buff + 8, "DELL    PERC", 12) || !memcmp(req_buff + 8, "MegaRAID", 8)
       || !memcmp(req_buff + 16, "PERC H", 6) || !memcmp(req_buff + 8, "LSI\0",4)
@@ -2507,11 +2507,10 @@ smart_device * freebsd_smart_interface::get_custom_smart_device(const char * nam
     }
     return new freebsd_areca_ata_device(this, name, disknum, encnum);
   }
-  
-    if (sscanf(type, "megaraid,%d", &disknum) == 1) {
+
+  if (sscanf(type, "megaraid,%d", &disknum) == 1) {
     return new freebsd_megaraid_device(this, name, disknum);
   }
-
 
   return 0;
 }

--- a/smartmontools/os_freebsd.cpp
+++ b/smartmontools/os_freebsd.cpp
@@ -31,7 +31,7 @@
 #include <stddef.h>
 #include <paths.h>
 #include <sys/utsname.h>
- 
+
 #include "config.h"
 
 // set by /usr/include/sys/ata.h, suppress warning

--- a/smartmontools/os_freebsd.h
+++ b/smartmontools/os_freebsd.h
@@ -608,6 +608,8 @@ HPT_PASS_THROUGH_HEADER, *PHPT_PASS_THROUGH_HEADER;
 
 // MFI definition from the kernel sources, see sys/dev/mfi
 
+#define MFI_STAT_OK  0x00
+
 /*
  * MFI Frame flags
  */

--- a/smartmontools/os_freebsd.h
+++ b/smartmontools/os_freebsd.h
@@ -608,7 +608,11 @@ HPT_PASS_THROUGH_HEADER, *PHPT_PASS_THROUGH_HEADER;
 
 // MFI definition from the kernel sources, see sys/dev/mfi
 
-#define MFI_STAT_OK  0x00
+#define MFI_STAT_OK          0x00
+#define MFI_DCMD_PD_GET_LIST 0x02010000
+
+#define MFI_CTRLR_PREFIX	"/dev/mfi"
+#define MRSAS_CTRLR_PREFIX	"/dev/mrsas"
 
 /*
  * MFI Frame flags

--- a/smartmontools/os_freebsd.h
+++ b/smartmontools/os_freebsd.h
@@ -698,6 +698,16 @@ struct mfi_pass_frame {
     union mfi_sgl       sgl;
 } __packed;
 
+#define MFI_DCMD_FRAME_SIZE     40
+#define MFI_MBOX_SIZE           12
+
+struct mfi_dcmd_frame {
+    struct mfi_frame_header header;
+    uint32_t	opcode;
+    uint8_t		mbox[MFI_MBOX_SIZE];
+    union mfi_sgl	sgl;
+} __packed;
+
 #define MAX_IOCTL_SGE   16
 struct mfi_ioc_packet {
     uint16_t    mfi_adapter_no;
@@ -730,6 +740,23 @@ struct mfi_ioc_packet32 {
     struct iovec32 mfi_sgl[MAX_IOCTL_SGE];
 } __packed;
 #endif
+
+struct mfi_pd_address {
+    uint16_t		device_id;
+    uint16_t		encl_device_id;
+    uint8_t			encl_index;
+    uint8_t			slot_number;
+    uint8_t			scsi_dev_type;	/* 0 = disk */
+    uint8_t			connect_port_bitmap;
+    uint64_t		sas_addr[2];
+} __packed;
+
+#define MAX_SYS_PDS 240
+struct mfi_pd_list {
+    uint32_t		size;
+    uint32_t		count;
+    struct mfi_pd_address	addr[MAX_SYS_PDS];
+} __packed;
 
 #define MFI_CMD		_IOWR('M', 1, struct mfi_ioc_packet)
 

--- a/smartmontools/os_freebsd.h
+++ b/smartmontools/os_freebsd.h
@@ -606,4 +606,131 @@ HPT_PASS_THROUGH_HEADER, *PHPT_PASS_THROUGH_HEADER;
 #define __unused __attribute__ ((__unused__))
 #endif
 
+// MFI definition from the kernel sources
+
+/*
+ * MFI Frame flags
+ */
+#define MFI_FRAME_POST_IN_REPLY_QUEUE           0x0000
+#define MFI_FRAME_DONT_POST_IN_REPLY_QUEUE      0x0001
+#define MFI_FRAME_SGL32                         0x0000
+#define MFI_FRAME_SGL64                         0x0002
+#define MFI_FRAME_SENSE32                       0x0000
+#define MFI_FRAME_SENSE64                       0x0004
+#define MFI_FRAME_DIR_NONE                      0x0000
+#define MFI_FRAME_DIR_WRITE                     0x0008
+#define MFI_FRAME_DIR_READ                      0x0010
+#define MFI_FRAME_DIR_BOTH                      0x0018
+#define MFI_FRAME_IEEE_SGL                      0x0020
+#define MFI_FRAME_FMT "\20" \
+    "\1NOPOST" \
+    "\2SGL64" \
+    "\3SENSE64" \
+    "\4WRITE" \
+    "\5READ" \
+    "\6IEEESGL"
+
+/* MFI Commands */
+typedef enum {
+    MFI_CMD_INIT =              0x00,
+    MFI_CMD_LD_READ,
+    MFI_CMD_LD_WRITE,
+    MFI_CMD_LD_SCSI_IO,
+    MFI_CMD_PD_SCSI_IO,
+    MFI_CMD_DCMD,
+    MFI_CMD_ABORT,
+    MFI_CMD_SMP,
+    MFI_CMD_STP
+} mfi_cmd_t;
+
+/* Scatter Gather elements */
+struct mfi_sg32 {
+    uint32_t    addr;
+    uint32_t    len;
+} __packed;
+
+struct mfi_sg64 {
+    uint64_t    addr;
+    uint32_t    len;
+} __packed;
+
+struct mfi_sg_skinny {
+    uint64_t    addr;
+    uint32_t    len;
+    uint32_t    flag;
+} __packed;
+
+union mfi_sgl {
+    struct mfi_sg32             sg32[1];
+    struct mfi_sg64             sg64[1];
+    struct mfi_sg_skinny        sg_skinny[1];
+} __packed;
+
+/* Message frames.  All messages have a common header */
+struct mfi_frame_header {
+    uint8_t             cmd;
+    uint8_t             sense_len;
+    uint8_t             cmd_status;
+    uint8_t             scsi_status;
+    uint8_t             target_id;
+    uint8_t             lun_id;
+    uint8_t             cdb_len;
+    uint8_t             sg_count;
+    uint32_t    context;
+    /*
+     * pad0 is MSI Specific. Not used by Driver. Zero the value before
+     * sending the command to f/w.
+     */
+    uint32_t    pad0;
+    uint16_t    flags;
+#define MFI_FRAME_DATAOUT       0x08
+#define MFI_FRAME_DATAIN        0x10
+    uint16_t    timeout;
+    uint32_t    data_len;
+} __packed;
+
+#define MFI_PASS_FRAME_SIZE 48
+struct mfi_pass_frame {
+    struct mfi_frame_header header;
+    uint32_t    sense_addr_lo;
+    uint32_t    sense_addr_hi;
+    uint8_t             cdb[16];
+    union mfi_sgl       sgl;
+} __packed;
+
+#define MAX_IOCTL_SGE   16
+struct mfi_ioc_packet {
+    uint16_t    mfi_adapter_no;
+    uint16_t    mfi_pad1;
+    uint32_t    mfi_sgl_off;
+    uint32_t    mfi_sge_count;
+    uint32_t    mfi_sense_off;
+    uint32_t    mfi_sense_len;
+    union {
+        uint8_t raw[128];
+        struct mfi_frame_header hdr;
+    } mfi_frame;
+
+    struct iovec mfi_sgl[MAX_IOCTL_SGE];
+} __packed;
+
+#ifdef COMPAT_FREEBSD32
+struct mfi_ioc_packet32 {
+    uint16_t    mfi_adapter_no;
+    uint16_t    mfi_pad1;
+    uint32_t    mfi_sgl_off;
+    uint32_t    mfi_sge_count;
+    uint32_t    mfi_sense_off;
+    uint32_t    mfi_sense_len;
+    union {
+        uint8_t raw[128];
+        struct mfi_frame_header hdr;
+    } mfi_frame;
+
+    struct iovec32 mfi_sgl[MAX_IOCTL_SGE];
+} __packed;
+#endif
+
+#define MFI_CMD		_IOWR('M', 1, struct mfi_ioc_packet)
+
 #endif /* OS_FREEBSD_H_ */

--- a/smartmontools/os_freebsd.h
+++ b/smartmontools/os_freebsd.h
@@ -606,7 +606,7 @@ HPT_PASS_THROUGH_HEADER, *PHPT_PASS_THROUGH_HEADER;
 #define __unused __attribute__ ((__unused__))
 #endif
 
-// MFI definition from the kernel sources
+// MFI definition from the kernel sources, see sys/dev/mfi
 
 /*
  * MFI Frame flags

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -503,6 +503,7 @@ FreeBSD:
 .br
 \fBsmartctl \-a \-d megaraid,0 /dev/mrsas0\fP
 .br
+.Sp
 .\" %ENDIF OS FreeBSD
 .\" %IF OS ALL
 Linux:

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -482,16 +482,32 @@ this device type is for NVMe disks that are behind a Realtek USB to NVMe
 bridge.
 .Sp
 .\" %ENDIF NOT OS Darwin
-.\" %IF OS Linux
+.\" %IF OS Linux FreeBSD
 .I marvell
 \- [Linux only] interact with SATA disks behind Marvell chip-set
 controllers (using the Marvell rather than libata driver).
 .Sp
 .I megaraid,N
-\- [Linux only] the device consists of one or more SCSI/SAS disks connected
+\- [FreeBSD and Linux only] the device consists of one or more SCSI/SAS disks connected
 to a MegaRAID controller.  The non-negative integer N (in the range of 0 to
-127 inclusive) denotes which disk on the controller is monitored.
+127 inclusive) denotes which disk on the controller is monitored. This interface
+will also work for Dell PERC controllers.
 Use syntax such as:
+.\" %ENDIF OS Linux FreeBSD
+.\" %IF OS ALL
+FreeBSD:
+.\" %ENDIF OS ALL
+.\" %IF OS FreeBSD
+.br
+\fBsmartctl \-a \-d megaraid,2 /dev/mfi0\fP
+.br
+\fBsmartctl \-a \-d megaraid,0 /dev/mrsas0\fP
+.br
+.\" %ENDIF OS FreeBSD
+.\" %IF OS ALL
+Linux:
+.\" %ENDIF OS ALL
+.\" %IF OS Linux
 .br
 \fBsmartctl \-a \-d megaraid,2 /dev/sda\fP
 .br
@@ -499,7 +515,6 @@ Use syntax such as:
 .br
 \fBsmartctl \-a \-d megaraid,0 /dev/bus/0\fP
 .br
-This interface will also work for Dell PERC controllers.
 It is possible to set RAID device name as /dev/bus/N, where N is a SCSI bus
 number.
 .Sp

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -116,15 +116,27 @@ Section below!
 # may become common with SATA disks in SAS and FC
 # environments.
 /dev/sda \-a \-d sat
-.\" %IF OS Linux
+.\" %IF OS FreeBSD Linux
 #
-# Three disks connected to a MegaRAID controller
+# Disks connected to a MegaRAID controller
 # Start short self\-tests daily between 1\-2, 2\-3, and
 # 3\-4 am.
+.\" %ENDIF OS FreeBSD Linux
+.\" %IF OS Linux
+# Linux:
 /dev/sda \-d megaraid,0 \-a \-s S/../.././01
 /dev/sda \-d megaraid,1 \-a \-s S/../.././02
 /dev/sda \-d megaraid,2 \-a \-s S/../.././03
 /dev/bus/0 \-d megaraid,2 \-a \-s S/../.././03
+.\" %ENDIF OS Linux
+.\" %IF OS FreeBSD
+# FreeBSD:
+/dev/mfi0 \-d megaraid,0 \-a \-s S/../.././01
+/dev/mfi0 \-d megaraid,1 \-a \-s S/../.././02
+/dev/mfi0 \-d megaraid,2 \-a \-s S/../.././03
+/dev/mrsas0 \-d megaraid,2 \-a \-s S/../.././03
+.\" %ENDIF OS FreeBSD
+.\" %IF OS Linux
 #
 # Three disks connected to an AacRaid controller
 # Start short self\-tests daily between 1\-2, 2\-3, and
@@ -468,18 +480,19 @@ bridge.
 \- [Linux only] interact with SATA disks behind Marvell chip-set
 controllers (using the Marvell rather than libata driver).
 .Sp
+.\" %ENDIF OS FreeBSD Linux
+.\" %IF OS FreeBSD Linux
 .I megaraid,N
-\- [Linux only] the device consists of one or more SCSI/SAS disks connected
+\- [Linux and FreeBSD only] the device consists of one or more SCSI/SAS disks connected
 to a MegaRAID controller.  The non-negative integer N (in the range of 0 to
 127 inclusive) denotes which disk on the controller is monitored.
 This interface will also work for Dell PERC controllers.
 In log files and email messages this disk will be identified as
 megaraid_disk_XXX with XXX in the range from 000 to 127 inclusive.
-It is possible to set RAID device name as /dev/bus/N, where N is a SCSI bus
-number.
+
 Please see the \fBsmartctl\fP(8) man page for further details.
 .Sp
-.\" %ENDIF OS Linux
+.\" %ENDIF OS FreeBSD Linux
 .\" %IF OS Linux Windows Cygwin
 .I aacraid,H,L,ID
 \- [Linux, Windows and Cygwin only] the device consists of one or more


### PR DESCRIPTION
## Story

This is related to https://www.smartmontools.org/ticket/734. It already works for me on mfi driver and i am looking for the `mrsas` access to test. Also tracked in FreeBSD bug tracker as https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=212211

## Todo

- [x] Implement SCSI access via MFI_CMD ioctl.
- [x] Check on `mfi` driver (done, FreeBSD 11 and FreeBSD 13 amd64)
- [x] Check on `mrsas` driver (done)
- [x] Implement scanning of the raid devices via DCMD command (`MFI_DCMD_PD_GET_LIST`)
- [x] Update man pages and NEWS