### PR TITLE
DB update: ST3500320AS needs xerrorlba

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -4022,6 +4022,7 @@ const drive_settings builtin_knowndrives[] = {
     "ST3(500[368]20|750[36]30|1000340)AS?",
     "SD1A", // http://knowledge.seagate.com/articles/en_US/FAQ/207951en
     "", ""
+    "-F xerrorlba"  // tested with ST3500320AS/SD1A
   },
   { "Seagate Barracuda 7200.11", // fixed firmware
     "ST3(160813|320[68]13|640[36]23|1000333|1500341)AS?",


### PR DESCRIPTION
Seagate Barracuda 7200.11 **ST3500320AS SD1A** needs _"-F xerrorlba"_ for fixing LBA byte ordering in Extended Comprehensive SMART error log.