### PR TITLE
scsiprint.cpp: Fix an invalid test on supported subpages

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,10 @@
 $Id$
 
+2021-11-08  Yannick Hemery  <yannick.hemery@corp.ovh.com>
+
+	scsiprint.cpp: Fix an invalid test on supported subpages, resulting
+	in all subpages other than zero to be ignored.
+
 2021-11-29  Christian Franke  <franke@computer.org>
 
 	smartctl.cpp: Fix possible buffer overflow (#1546).

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -179,7 +179,6 @@ scsiGetSupportedLogPages(scsi_device * device)
             bump = 1;
             up = sup_lpgs + LOGPAGEHDRSIZE;
             got_subpages = false;
-            (void)got_subpages; // not yet used below, suppress warning
         } else {
             resp_len = resp_len_pg0_ff;
             bump = 2;
@@ -194,7 +193,7 @@ scsiGetSupportedLogPages(scsi_device * device)
     num_unreported_spg = 0;
     for (num_unreported = 0, k = 0; k < resp_len; k += bump, up += bump) {
         uint8_t pg_num = 0x3f & up[0];
-        uint8_t sub_pg_num = (0x40 & up[0]) ? up[1] : 0;
+        uint8_t sub_pg_num = got_subpages ? up[1] : 0;
 
         switch (pg_num)
         {


### PR DESCRIPTION
The previously tested bit 0x40 & up[0] is a reserved bit that should
always be zero. The original intention was probably to test the SPF bit
in the response header.

For example, on the following SSD:

```
root@rescue:~/smartmontools# sg_logs -p 0x00,0xff /dev/sg0
    SAMSUNG   MZILT3T8HBLS/007  GXA0
Supported log pages and subpages  [0x0, 0xff]:
    0x00,0xff   Supported log pages and subpages
    0x0d        Temperature
    0x0d,0x01   ??
    0x0d,0x02   ??
    0x0d,0xff   Temperature and subpages
    0x15        Background scan results
    0x15,0x01   Pending defects
    0x15,0xff   ??
```

With the previous version of the code (and a debug log), the subpage code was always set to 0:
```
scsiGetSupportedLogPages: pg_num=0, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=13, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=13, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=13, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=13, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=21, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=21, sub_pg_num=0
scsiGetSupportedLogPages: pg_num=21, sub_pg_num=0
```
And as a result, the Pending defects subpage was not displayed as it should.