### PR TITLE
config support for idle_a, idle_b, idle_c

### DIFF
--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -3481,22 +3481,22 @@ static int ATACheckDevice(const dev_config & cfg, dev_state & state, ata_device 
       if (cfg.powermode>=3)
         dontcheck=1;
       break;
-    case 0x81:
-      // IDLE_A
-      mode="IDLE_A";
-      if (cfg.powermode>=3)
+    case 0x83:
+      // IDLE_C
+      mode="IDLE_C";
+      if (cfg.powermode>=4)
         dontcheck=1;
       break;
     case 0x82:
       // IDLE_B
       mode="IDLE_B";
-      if (cfg.powermode>=3)
+      if (cfg.powermode>=5)
         dontcheck=1;
       break;
-    case 0x83:
-      // IDLE_C
-      mode="IDLE_C";
-      if (cfg.powermode>=3)
+    case 0x81:
+      // IDLE_A
+      mode="IDLE_A";
+      if (cfg.powermode>=6)
         dontcheck=1;
       break;
     case 0xff:
@@ -4346,6 +4346,12 @@ static int ParseToken(char * token, dev_config & cfg, smart_devtype_list & scan_
         cfg.powermode = 2;
       else if (!strcmp(arg, "idle"))
         cfg.powermode = 3;
+      else if (!strcmp(arg, "idle_c"))
+        cfg.powermode = 4;
+      else if (!strcmp(arg, "idle_b"))
+        cfg.powermode = 5;
+      else if (!strcmp(arg, "idle_a"))
+        cfg.powermode = 6;
       else
         badarg = 1;
 

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -3482,27 +3482,27 @@ static int ATACheckDevice(const dev_config & cfg, dev_state & state, ata_device 
       if (cfg.powermode>=2)
         dontcheck=1;
       break;
-    case 0x80:
-      // IDLE
-      mode="IDLE";
-      if (cfg.powermode>=3)
-        dontcheck=1;
-      break;
     case 0x83:
       // IDLE_C
       mode="IDLE_C";
-      if (cfg.powermode>=4)
+      if (cfg.powermode>=3)
         dontcheck=1;
       break;
     case 0x82:
       // IDLE_B
       mode="IDLE_B";
-      if (cfg.powermode>=5)
+      if (cfg.powermode>=4)
         dontcheck=1;
       break;
     case 0x81:
       // IDLE_A
       mode="IDLE_A";
+      if (cfg.powermode>=5)
+        dontcheck=1;
+      break;
+    case 0x80:
+      // IDLE
+      mode="IDLE";
       if (cfg.powermode>=6)
         dontcheck=1;
       break;
@@ -4396,13 +4396,13 @@ static int ParseToken(char * token, dev_config & cfg, smart_devtype_list & scan_
         cfg.powermode = 1;
       else if (!strcmp(arg, "standby"))
         cfg.powermode = 2;
-      else if (!strcmp(arg, "idle"))
-        cfg.powermode = 3;
       else if (!strcmp(arg, "idle_c"))
-        cfg.powermode = 4;
+        cfg.powermode = 3;
       else if (!strcmp(arg, "idle_b"))
-        cfg.powermode = 5;
+        cfg.powermode = 4;
       else if (!strcmp(arg, "idle_a"))
+        cfg.powermode = 5;
+      else if (!strcmp(arg, "idle"))
         cfg.powermode = 6;
       else
         badarg = 1;


### PR DESCRIPTION
When it comes to "skip disk check or not", the states idle_a / idle_b / idle_c were considered idle states. This is not optimal, since e.g. most Seagate disks switch to idle_a after 100 ms (back to active in < 1 ms), while switching back from idle_c to active takes ~ 2 seconds because the heads are unloaded and the rpm is reduced.

This pull request adds the functionality to use idle_a / idle_b / idle_c in addition to "idle" in the config file while preserving the previous behavior if "idle" is used in the config file.