### PR TITLE
Prevent systemd unit startup timeout when registering many devices

### DIFF
--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -236,6 +236,7 @@ static void PrintOut(int priority, const char *fmt, ...)
 // systemd notify support
 
 static bool notify_enabled = false;
+static bool notify_ready = false;
 
 static inline void notify_init()
 {
@@ -253,6 +254,20 @@ static inline bool notify_post_init()
     return false;
   }
   return true;
+}
+
+static inline void notify_extend_timeout()
+{
+  if (!notify_enabled)
+    return;
+  if (notify_ready)
+    return;
+  const char * notify = "EXTEND_TIMEOUT_USEC=20000000"; // typical drive spinup time is 20s tops
+  if (debugmode) {
+    pout("sd_notify(0, \"%s\")\n", notify);
+    return;
+  }
+  sd_notify(0, notify);
 }
 
 static void notify_msg(const char * msg, bool ready = false)
@@ -285,9 +300,8 @@ static void notify_wait(time_t wakeuptime, int numdev)
   char msg[64];
   snprintf(msg, sizeof(msg), "Next check of %d device%s will start at %s",
            numdev, (numdev != 1 ? "s" : ""), ts);
-  static bool ready = true; // first call notifies READY=1
-  notify_msg(msg, ready);
-  ready = false;
+  notify_msg(msg, !notify_ready); // first call notifies READY=1
+  notify_ready = true;
 }
 
 static void notify_exit(int status)
@@ -322,6 +336,7 @@ static inline bool notify_post_init()
 }
 
 static inline void notify_init() { }
+static inline void notify_extend_timeout() { }
 static inline void notify_msg(const char *) { }
 static inline void notify_check(int) { }
 static inline void notify_wait(time_t, int) { }
@@ -5568,6 +5583,9 @@ static bool register_devices(const dev_config_vector & conf_entries, smart_devic
         scanning = true;
       }
     }
+
+    // Prevent systemd unit startup timeout when registering many devices
+    notify_extend_timeout();
 
     // Register device
     // If scanning, pass dev_idinfo of previous devices for duplicate check


### PR DESCRIPTION
On slow systems with many drives this can happen:
```
May 16 01:59:49 truenas smartd[1896037]: smartd 7.2 2020-12-30 r5155 [x86_64-linux-5.10.109+truenas] (local build)
May 16 01:59:49 truenas smartd[1896037]: Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org
May 16 01:59:49 truenas smartd[1896037]: Opened configuration file /etc/smartd.conf
May 16 01:59:49 truenas smartd[1896037]: Configuration file /etc/smartd.conf parsed.
May 16 01:59:49 truenas smartd[1896037]: Device: /dev/sdac [SAT], opened
May 16 01:59:49 truenas smartd[1896037]: Device: /dev/sdac [SAT], TOSHIBA MG08ACA16TE, S/N:41F0A0NTFVGG, WWN:5-000039-ad8cb8ccb, FW:0102, 16.0 TB
May 16 01:59:49 truenas smartd[1896037]: Device: /dev/sdac [SAT], not found in smartd database.
May 16 01:59:49 truenas smartd[1896037]: Device: /dev/sdac [SAT], is SMART capable. Adding to "monitor" list.
...
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiz [SAT], not found in smartd database.
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiz [SAT], is SMART capable. Adding to "monitor" list.
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiy, type changed from 'scsi' to 'sat'
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiy [SAT], opened
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiy [SAT], ST18000NM000J-2TV103, S/N:ZR52YPB5, WWN:5-000c50-0dbeffb9b, FW:SN02, 18.0 TB
May 16 02:01:19 truenas smartd[1896037]: Device: /dev/sdiy [SAT], not found in smartd database.
May 16 02:01:19 truenas systemd[1]: smartmontools.service: start operation timed out. Terminating.
May 16 02:01:19 truenas systemd[1]: smartmontools.service: Failed with result 'timeout'.
May 16 02:01:19 truenas systemd[1]: Failed to start Self Monitoring and Reporting Technology (SMART) Daemon.
```
It takes more than 90 seconds to open 600+ drives for S.M.A.R.T. monitoring and systemd unit times out. We send `EXTEND_TIMEOUT_USEC` notification after each opened drive to avoid that.