### PR TITLE
Add support for ViaLabs VL717

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -6243,8 +6243,8 @@ const drive_settings builtin_knowndrives[] = {
     "", // 0x0507, Intenso 2,5" Memory Case 2TB USB3
     "-d sat"
   },
-  { "USB: ; VIA VL715/6", // USB2/3->SATA, USB-C->SATA
-    "0x2109:0x071[56]",
+  { "USB: ; VIA VL715/6/7", // USB2/3->SATA, USB-C->SATA
+    "0x2109:0x071[567]",
     "", // 0x0336/0x0000
     "",
     "-d sat"


### PR DESCRIPTION
This USB SATA controller requires to choose "SAT" protocol, similar to previous controllers VL715 and VL716.

Originally, I had to provide "-d SAT" on command line explicitly to make the controller work with current smartmontools 7.3. An explicit drivedb entry avoids this.

lsusb:

```
Bus 004 Device 004: ID 2109:0717 VIA Labs, Inc. HDD Docking Station
Bus 004 Device 003: ID 2109:0717 VIA Labs, Inc. HDD Docking Station
...
```

Specific vendor/product name of tested VL717 controller variant: "‎Inateck USB3.2 Gen2 Docking Station", model number FD2024.
Has two dock drive slots, relating to abovecited two USB devices.