### PR TITLE
allow printing all xselftest / defects log

### DIFF
--- a/smartmontools/ataprint.h
+++ b/smartmontools/ataprint.h
@@ -41,6 +41,7 @@ struct ata_print_options
   bool gp_logdir = false, smart_logdir = false;
   unsigned smart_ext_error_log = 0;
   unsigned smart_ext_selftest_log = 0;
+  bool smart_ext_selftest_log_all = false;
   bool retry_error_log = false, retry_selftest_log = false;
 
   std::vector<ata_log_request> log_requests;
@@ -49,6 +50,7 @@ struct ata_print_options
   std::vector<int> devstat_pages;
 
   unsigned pending_defects_log = 0;
+  bool pending_defects_log_all = false;
 
   bool sct_temp_sts = false, sct_temp_hist = false;
   int sct_erc_get = 0; // get(1), get_power_on(2)

--- a/smartmontools/json.cpp
+++ b/smartmontools/json.cpp
@@ -68,7 +68,7 @@ json::ref::ref(const ref & base, const char * keystr)
 json::ref::ref(const ref & base, int index)
 : m_js(base.m_js), m_path(base.m_path)
 {
-  jassert(0 <= index && index < 10000); // Limit: large arrays not supported
+  jassert(0 <= index && index < (2 << 20)); // Limit: large arrays not supported
   m_path.push_back(node_info(index));
 }
 

--- a/smartmontools/smartctl.cpp
+++ b/smartmontools/smartctl.cpp
@@ -179,11 +179,11 @@ static void Usage()
 "        Set output format for attributes: old, brief, hex[,id|val]\n\n"
 "  -l TYPE, --log=TYPE\n"
 "        Show device log. TYPE: error, selftest, selective, directory[,g|s],\n"
-"        xerror[,N][,error], xselftest[,N][,selftest], background,\n"
+"        xerror[,N][,error], xselftest[,N|all][,selftest], background,\n"
 "        sasphy[,reset], sataphy[,reset], scttemp[sts,hist],\n"
-"        scttempint,N[,p], scterc[,N,M][,p|reset], devstat[,N], defects[,N],\n"
-"        ssd, gplog,N[,RANGE], smartlog,N[,RANGE], nvmelog,N,SIZE\n"
-"        tapedevstat, zdevstat, envrep\n\n"
+"        scttempint,N[,p], scterc[,N,M][,p|reset], devstat[,N],\n"
+"        defects[,N|all], ssd, gplog,N[,RANGE], smartlog,N[,RANGE],\n"
+"        nvmelog,N,SIZE, tapedevstat, zdevstat, envrep\n\n"
 "  -v N,OPTION , --vendorattribute=N,OPTION                            (ATA)\n"
 "        Set display OPTION for vendor Attribute N (see man page)\n\n"
 "  -F TYPE, --firmwarebug=TYPE                                         (ATA)\n"
@@ -597,6 +597,8 @@ static int parse_options(int argc, char** argv, const char * & type,
           ataopts.pending_defects_log = 31; // Entries of first page
         else if (n2 == len && val <= 0xffff * 32 - 1)
           ataopts.pending_defects_log = val;
+        else if (!strcmp(optarg, "defects,all"))
+          ataopts.pending_defects_log_all = true;
         else
           badarg = true;
 
@@ -628,7 +630,18 @@ static int parse_options(int argc, char** argv, const char * & type,
           ataopts.retry_selftest_log = (n2 == len);
         }
         else
-          badarg = true;
+        {
+          sscanf(optarg, "xselftest,all%n,selftest%n", &n1, &n2);
+          if (n1 == len || n2 == len)
+          {
+            ataopts.smart_ext_selftest_log_all = true;
+            ataopts.retry_selftest_log = (n2 == len);
+          }
+          else
+          {
+            badarg = true;
+          }
+        }
 
       } else if (!strncmp(optarg, "scterc,", sizeof("scterc,")-1)) {
         int n1 = -1, n2 = -1, len = strlen(optarg);


### PR DESCRIPTION
Hi,
I add the ability to print all xselftest / defect log by `-l xselftest,all` & `-l defects,all`.
So user could print all logs with input an explicitly large entry count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to display all entries from Extended Self-Test and Pending Defects logs, allowing users to view complete diagnostic histories instead of limited subsets.

* **Improvements**
  * Enhanced JSON output handling to support larger data arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->