### PR TITLE
drivedb.h: WDC WD200EDGZ-11BLDS0

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3657,6 +3657,13 @@ const drive_settings builtin_knowndrives[] = {
     "", "",
     "-v 22,raw48,Helium_Level" // not: WD80EDAZ
   },
+  { "Western Digital Ultrastar (DC HC560)", // WD white label, tested with
+      // WDC WD200EDGZ-11BLDS0/85.00A85 (Elements 0x1058:0x25a3)
+    "WDC WD(200)E(DG)Z-.*",
+    "", "",
+    "-v 22,raw48,Helium_Level "
+    "-v 90,hex48,NAND_Master"
+  },
   { "HGST Ultrastar DC HC520 (He12)", // tested with HGST HUH721212ALE600/LEGNT3D0
     "HGST HUH721212AL[EN]60[014]",
     "", "",


### PR DESCRIPTION
Noticed the recent batch of 20TB variant of WD white labelled drives are not yet in the drive database. These drives shares the same R/N as HC560 just like 20TB Red Pro and Gold, and share the same SMART vendor specific values. 

smartmontools output for the drive: 
```plaintext
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-5.19.0-38-generic] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     WDC WD200EDGZ-11BLDS0
Serial Number:    **REDACTED**
LU WWN Device Id: 5 000cca **REDACTED**
Firmware Version: 85.00A85
User Capacity:    20,000,588,955,648 bytes [20.0 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    7200 rpm
Form Factor:      3.5 inches
Device is:        Not in smartctl database 7.3/5319
ATA Version is:   ACS-5 (minor revision not indicated)
SATA Version is:  SATA 3.5, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Sun Apr 16 13:25:42 2023 AEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x82)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Enabled.
Self-test execution status:      ( 244)	Self-test routine in progress...
					40% of test remaining.
Total time to complete Offline
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x5b) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (2242) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000b   100   100   001    Pre-fail  Always       -       0
  2 Throughput_Performance  0x0004   146   146   000    Old_age   Offline      -       55
  3 Spin_Up_Time            0x0007   096   096   001    Pre-fail  Always       -       232
  4 Start_Stop_Count        0x0012   100   100   000    Old_age   Always       -       5
  5 Reallocated_Sector_Ct   0x0033   100   100   001    Pre-fail  Always       -       0
  7 Seek_Error_Rate         0x000a   100   100   000    Old_age   Always       -       0
  8 Seek_Time_Performance   0x0004   140   140   000    Old_age   Offline      -       15
  9 Power_On_Hours          0x0012   100   100   000    Old_age   Always       -       48
 10 Spin_Retry_Count        0x0012   100   100   000    Old_age   Always       -       0
 12 Power_Cycle_Count       0x0032   100   100   000    Old_age   Always       -       5
 22 Unknown_Attribute       0x0023   100   100   025    Pre-fail  Always       -       6553700
 90 Unknown_Attribute       0x0031   100   100   001    Pre-fail  Offline      -       317827579904
192 Power-Off_Retract_Count 0x0032   100   100   000    Old_age   Always       -       6
193 Load_Cycle_Count        0x0012   100   100   000    Old_age   Always       -       6
194 Temperature_Celsius     0x0002   015   015   000    Old_age   Always       -       56 (Min/Max 22/61)
196 Reallocated_Event_Count 0x0032   100   100   000    Old_age   Always       -       0
197 Current_Pending_Sector  0x0022   100   100   000    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0008   100   100   000    Old_age   Offline      -       0
199 UDMA_CRC_Error_Count    0x000a   100   100   000    Old_age   Always       -       0

SMART Error Log Version: 1
No Errors Logged

SMART Self-test log structure revision number 1
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.
```