### PR TITLE
drivedb.h: Add ATP SATA III SSDs

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -287,6 +287,61 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 199,raw48,UDMA_CRC_Error_Count "
   //"-v 240,raw48,Unknown_SSD_Attribute "
   },
+  { "ATP SATA III Value Line SSDs",
+    "ATP SATA III (M.2 (2242|2280)|mSATA|mSATA SSD|2.5 inch)", // tested M.2 2280 with firmware version SBFMBB.3 (Value Line)
+    "SBFMB1.1|SBFMBB.3|SBFMT1.3",
+    "",
+    "-v 1,raw48,Raw_Read_Error_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 170,raw16,Bad_Bl_Ct_LATER_0_EARLY " // Raw value: Byte [5~4] Later bad block count
+                                            //            Byte [3~2] 0
+                                            //            Byte [1~0] Early bad block count (meaning see ticket #1642)
+    "-v 173,raw16,Erase_Count_0_AVG_MAX "   // Raw value: Byte [5~4] 0
+                                            //            Byte [3~2] Average erase count
+                                            //            Byte [1~0] Max erase count
+    "-v 192,raw48,Unexpected_Power_Loss "
+  //"-v 194,tempminmax,Device_Temperature "
+    "-v 218,raw48,CRC_Errors "
+    "-v 231,raw48,Percent_Lifetime_Remain "
+    "-v 241,raw48,Host_Writes_GiB "
+  },
+  { "ATP SATA III Superior Line SSDs",
+    "ATP (SATA III|SATAIII|I-Temp. SATA III|I-Temp. SATAIII) (M.2 (2242|2280)|mSATA|2.5 inch) SSD", // tested M.2 2242 & 2280 with firmware version T0205B (Superior Line with PLP)
+    "T0205B|U0316B",
+    "",
+    "-v 1,raw48,Raw_Read_Error_Count "
+    "-v 5,raw16(raw16),Realloc_Flash_Blocks_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 14,raw48,Device_Raw_Capacity "
+    "-v 15,raw48,Device_User_Capacity "
+    "-v 16,raw48,Initial_Spare_Blocks "
+    "-v 17,raw48,Remaining_Spare_Blocks "
+    "-v 100,raw48,Total_Erease_Count "
+    "-v 160,raw48,Uncorrectable_Sectors "
+    "-v 172,raw48,Block_Erase_Failures "
+    "-v 173,raw48,Maximum_Erase_Count "
+    "-v 174,raw48,Unexpected_Power_Loss "
+    "-v 175,raw48,Average_Erase_Count "
+    "-v 181,raw48,Block_Program_Failures "
+    "-v 187,raw48,Reported_Uncorr_Errors "
+  //"-v 194,tempminmax,Device_Temperature "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 197,raw48,Current_Pending_ECC_Cnt " // Like Crucial MX500: May flip 0 <> 1 (ticket #1227)
+    "-v 198,raw48,Offline_UErr_Media_Scan "
+    "-v 199,raw48,SATA_FIS_CRC_Errors "
+    "-v 202,raw48,Percent_Lifetime_Used "
+    "-v 205,raw48,Thermal_Asperity_Rate "
+    "-v 231,tempminmax,Controller_Temperature "
+    "-v 234,raw48,Sectors_Read_from_NAND "
+    "-v 235,raw48,Sectors_Written_to_SSD "
+    "-v 241,raw48,Sectors_Written_to_NAND "
+    "-v 242,raw48,Sectors_Read_from_SSD "
+    "-v 248,raw48,Percent_Lifetime_Remain "
+    "-v 249,raw48,Spare_Blocks_Remaining " // same as ID 17 (Remaining_Spare_Blocks)
+  },
   { "ATP SATA III aMLC M.2 2242 Embedded SSD",
     "ATP I-Temp M\\.2 2242", // tested with ATP I-Temp M.2 2242/R0822A
     "","",


### PR DESCRIPTION
- Add ATP Electronics Value Line and Superior Line SATA SSDs
- Distinguish between them based on firmware versions
- SSDs:
  - Value LIne (Phison based)
  - Superior Line (Silicon Motion based)

Here are two examples of the smartctl -x output with those drives:

1. Value Line Drive
```
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0-7-amd64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     ATP SATA III Value Line SSDs
Device Model:     ATP SATA III M.2 2280
Serial Number:    22090026-000001
LU WWN Device Id: 0 000000 000000000
Firmware Version: SBFMBB.3
User Capacity:    64,023,257,088 bytes [64.0 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      M.2
TRIM Command:     Available
Device is:        In smartctl database
ATA Version is:   ACS-4 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Fri Apr 28 11:47:38 2023 CEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]
Wt Cache Reorder: Unavailable

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(65535) seconds.
Offline data collection
capabilities: 			 (0x79) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  30) minutes.
Conveyance self-test routine
recommended polling time: 	 (   6) minutes.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Count    PO-R--   100   100   050    -    0
  9 Power_On_Hours          -O--C-   100   100   000    -    341
 12 Power_Cycle_Count       -O--C-   100   100   000    -    113
168 SATA_PHY_Error_Count    -O--C-   100   100   000    -    0
170 Bad_Bl_Ct_LATER_0_EARLY PO----   049   049   010    -    0 0 46
173 Erase_Count_0_AVG_MAX   -O--C-   100   100   000    -    0 4 13
192 Unexpected_Power_Loss   -O--C-   100   100   000    -    52
194 Temperature_Celsius     PO---K   067   067   000    -    33 (Min/Max 33/33)
218 CRC_Errors              PO-R--   100   100   050    -    0
231 Percent_Lifetime_Remain PO--C-   100   100   000    -    99
241 Host_Writes_GiB         -O--C-   100   100   000    -    88
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O     51  Comprehensive SMART error log
0x03       GPL     R/O     64  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log

SMART Extended Comprehensive Error Log Version: 1 (64 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Selective self-test log data structure revision number 0
Note: revision number not 1 implies that no selective self-test has ever been run
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Commands not supported

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4             113  ---  Lifetime Power-On Resets
0x01  0x010  4             341  ---  Power-on Hours
0x01  0x018  6       185969014  ---  Logical Sectors Written
0x01  0x028  6        30989743  ---  Logical Sectors Read
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              33  ---  Current Temperature
0x05  0x020  1              33  ---  Highest Temperature
0x05  0x028  1              33  ---  Lowest Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            0  Command failed due to ICRC error
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
0x0008  2            0  Device-to-host non-data FIS retries
0x0009  4            2  Transition from drive PhyRdy to drive PhyNRdy
0x000a  4            3  Device-to-host register FISes sent due to a COMRESET
0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC
```

2. Superior Line Drive
```
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0-7-amd64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     ATP SATA III Superior Line SSDs
Device Model:     ATP SATA III M.2 2280 SSD
Serial Number:    22060282-000127
LU WWN Device Id: 5 141357 170023ec5
Firmware Version: T0205B
User Capacity:    120,034,123,776 bytes [120 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      M.2
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.3, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Fri Apr 28 12:21:44 2023 CEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM level is:     254 (maximum performance)
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]
Wt Cache Reorder: Unknown

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x80)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Enabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x7b) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0002)	Does not save SMART data before
					entering power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   1) minutes.
Extended self-test routine
recommended polling time: 	 (  30) minutes.
Conveyance self-test routine
recommended polling time: 	 (   1) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Count    POSR-K   100   100   000    -    0
  5 Realloc_Flash_Blocks_Ct -O--CK   100   100   010    -    0
  9 Power_On_Hours          -O--CK   100   100   000    -    13
 12 Power_Cycle_Count       -O--CK   100   100   000    -    29
 14 Device_Raw_Capacity     -O--CK   100   100   000    -    317915136
 15 Device_User_Capacity    -O--CK   100   100   000    -    234441648
 16 Initial_Spare_Blocks    -O--CK   100   100   000    -    83
 17 Remaining_Spare_Blocks  PO--CK   000   000   000    -    17
100 Total_Erease_Count      -O--CK   100   100   000    -    3589
160 Uncorrectable_Sectors   -O--CK   100   100   000    -    0
172 Block_Erase_Failures    -O--CK   100   100   000    -    0
173 Maximum_Erase_Count     -O--CK   100   100   000    -    12
174 Unexpected_Power_Loss   -O--CK   100   100   000    -    2
175 Average_Erase_Count     -O--CK   100   100   000    -    7
181 Block_Program_Failures  -O--CK   100   100   000    -    0
187 Reported_Uncorr_Errors  -O--CK   100   100   000    -    0
194 Temperature_Celsius     -O---K   038   072   000    -    38 (Min/Max 0/38)
195 Hardware_ECC_Recovered  -O--CK   100   100   000    -    0
197 Current_Pending_ECC_Cnt -O--CK   100   100   000    -    0
198 Offline_UErr_Media_Scan ----CK   100   100   000    -    0
199 SATA_FIS_CRC_Errors     -O--CK   100   100   000    -    0
202 Percent_Lifetime_Used   ----CK   100   100   000    -    0
205 Thermal_Asperity_Rate   -O--CK   100   100   000    -    0
231 Controller_Temperature  -O---K   054   102   000    -    54 (Min/Max 32/54)
234 Sectors_Read_from_NAND  -O--CK   100   100   000    -    348455488
235 Sectors_Written_to_SSD  -O--CK   100   100   000    -    681308142
241 Sectors_Written_to_NAND -O--CK   100   100   000    -    1037219776
242 Sectors_Read_from_SSD   -O--CK   100   100   000    -    30345461
248 Percent_Lifetime_Remain ----CK   100   100   001    -    100
249 Spare_Blocks_Remaining  PO--CK   000   000   000    -    17
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O      1  Comprehensive SMART error log
0x03       GPL     R/O      1  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x24       GPL     R/O     88  Current Device Internal Status Data log
0x25       GPL     R/O     64  Saved Device Internal Status Data log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (1 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Completed [00% left] (0-65535)
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       1 (0x0001)
Device State:                        Active (0)
Current Temperature:                    38 Celsius
Power Cycle Min/Max Temperature:     --/38 Celsius
Lifetime    Min/Max Temperature:     --/72 Celsius

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      0/100 Celsius
Min/Max Temperature Limit:            0/100 Celsius
Temperature History Size (Index):    128 (62)

Index    Estimated Time   Temperature Celsius
  63    2023-04-28 10:14    64  ***************************************+
  64    2023-04-28 10:15    64  ***************************************+
  65    2023-04-28 10:16    65  ***************************************+
  66    2023-04-28 10:17    64  ***************************************+
  67    2023-04-28 10:18    64  ***************************************+
  68    2023-04-28 10:19     ?  -
  69    2023-04-28 10:20     ?  -
  70    2023-04-28 10:21    32  *************
  71    2023-04-28 10:22    34  ***************
  72    2023-04-28 10:23    40  *********************
  73    2023-04-28 10:24    41  **********************
  74    2023-04-28 10:25    41  **********************
  75    2023-04-28 10:26    42  ***********************
  76    2023-04-28 10:27    45  **************************
  77    2023-04-28 10:28    47  ****************************
  78    2023-04-28 10:29    48  *****************************
  79    2023-04-28 10:30    49  ******************************
  80    2023-04-28 10:31    50  *******************************
  81    2023-04-28 10:32    50  *******************************
  82    2023-04-28 10:33    51  ********************************
  83    2023-04-28 10:34    48  *****************************
 ...    ..(  2 skipped).    ..  *****************************
  86    2023-04-28 10:37    48  *****************************
  87    2023-04-28 10:38    49  ******************************
  88    2023-04-28 10:39    48  *****************************
  89    2023-04-28 10:40     ?  -
  90    2023-04-28 10:41     ?  -
  91    2023-04-28 10:42    49  ******************************
  92    2023-04-28 10:43    48  *****************************
  93    2023-04-28 10:44    49  ******************************
  94    2023-04-28 10:45     ?  -
 ...    ..(  4 skipped).    ..  -
  99    2023-04-28 10:50     ?  -
 100    2023-04-28 10:51    49  ******************************
 101    2023-04-28 10:52     ?  -
 ...    ..(  3 skipped).    ..  -
 105    2023-04-28 10:56     ?  -
 106    2023-04-28 10:57    48  *****************************
 107    2023-04-28 10:58    49  ******************************
 ...    ..(  5 skipped).    ..  ******************************
 113    2023-04-28 11:04    49  ******************************
 114    2023-04-28 11:05    50  *******************************
 ...    ..(  2 skipped).    ..  *******************************
 117    2023-04-28 11:08    50  *******************************
 118    2023-04-28 11:09    51  ********************************
 ...    ..(  2 skipped).    ..  ********************************
 121    2023-04-28 11:12    51  ********************************
 122    2023-04-28 11:13    52  *********************************
 123    2023-04-28 11:14     ?  -
 124    2023-04-28 11:15     ?  -
 125    2023-04-28 11:16    52  *********************************
 126    2023-04-28 11:17     ?  -
 127    2023-04-28 11:18     ?  -
   0    2023-04-28 11:19     ?  -
   1    2023-04-28 11:20    52  *********************************
   2    2023-04-28 11:21     ?  -
   3    2023-04-28 11:22     ?  -
   4    2023-04-28 11:23     ?  -
   5    2023-04-28 11:24    52  *********************************
   6    2023-04-28 11:25    56  *************************************
   7    2023-04-28 11:26    59  ****************************************
   8    2023-04-28 11:27    60  ***************************************+
   9    2023-04-28 11:28    59  ****************************************
  10    2023-04-28 11:29    57  **************************************
  11    2023-04-28 11:30     ?  -
  12    2023-04-28 11:31     ?  -
  13    2023-04-28 11:32    56  *************************************
  14    2023-04-28 11:33    55  ************************************
  15    2023-04-28 11:34    55  ************************************
  16    2023-04-28 11:35    56  *************************************
  17    2023-04-28 11:36    60  ***************************************+
  18    2023-04-28 11:37    62  ***************************************+
  19    2023-04-28 11:38    62  ***************************************+
  20    2023-04-28 11:39    63  ***************************************+
  21    2023-04-28 11:40    64  ***************************************+
  22    2023-04-28 11:41    59  ****************************************
  23    2023-04-28 11:42    58  ***************************************
  24    2023-04-28 11:43    57  **************************************
  25    2023-04-28 11:44    57  **************************************
  26    2023-04-28 11:45    57  **************************************
  27    2023-04-28 11:46    61  ***************************************+
  28    2023-04-28 11:47    64  ***************************************+
  29    2023-04-28 11:48    65  ***************************************+
  30    2023-04-28 11:49    65  ***************************************+
  31    2023-04-28 11:50    62  ***************************************+
  32    2023-04-28 11:51    59  ****************************************
  33    2023-04-28 11:52    58  ***************************************
  34    2023-04-28 11:53    57  **************************************
  35    2023-04-28 11:54    57  **************************************
  36    2023-04-28 11:55    57  **************************************
  37    2023-04-28 11:56    56  *************************************
  38    2023-04-28 11:57    55  ************************************
  39    2023-04-28 11:58    55  ************************************
  40    2023-04-28 11:59    55  ************************************
  41    2023-04-28 12:00    54  ***********************************
  42    2023-04-28 12:01    54  ***********************************
  43    2023-04-28 12:02    54  ***********************************
  44    2023-04-28 12:03    53  **********************************
 ...    ..( 10 skipped).    ..  **********************************
  55    2023-04-28 12:14    53  **********************************
  56    2023-04-28 12:15    54  ***********************************
 ...    ..(  2 skipped).    ..  ***********************************
  59    2023-04-28 12:18    54  ***********************************
  60    2023-04-28 12:19     ?  -
  61    2023-04-28 12:20     ?  -
  62    2023-04-28 12:21    36  *****************

SCT Error Recovery Control:
           Read: Disabled
          Write: Disabled

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4              29  ---  Lifetime Power-On Resets
0x01  0x010  4              13  ---  Power-on Hours
0x01  0x018  6       681308142  ---  Logical Sectors Written
0x01  0x020  6         3790238  ---  Number of Write Commands
0x01  0x028  6        30345461  ---  Logical Sectors Read
0x01  0x030  6          341383  ---  Number of Read Commands
0x01  0x038  6        48818870  ---  Date and Time TimeStamp
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               3  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              38  ---  Current Temperature
0x05  0x010  1              47  ---  Average Short Term Temperature
0x05  0x018  1              47  ---  Average Long Term Temperature
0x05  0x020  1              72  ---  Highest Temperature
0x05  0x028  1               0  ---  Lowest Temperature
0x05  0x030  1              57  ---  Highest Average Short Term Temperature
0x05  0x038  1               0  ---  Lowest Average Short Term Temperature
0x05  0x040  1              57  ---  Highest Average Long Term Temperature
0x05  0x048  1               0  ---  Lowest Average Long Term Temperature
0x05  0x050  4              50  ---  Time in Over-Temperature
0x05  0x058  1              65  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4             148  ---  Number of Hardware Resets
0x06  0x010  4              17  ---  Number of ASR Events
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            0  Command failed due to ICRC error
0x0002  2            0  R_ERR response for data FIS
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0005  2            0  R_ERR response for non-data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
0x0008  2            0  Device-to-host non-data FIS retries
0x0009  2            0  Transition from drive PhyRdy to drive PhyNRdy
0x000a  2            3  Device-to-host register FISes sent due to a COMRESET
0x000b  2            0  CRC errors within host-to-device FIS
0x000d  2            0  Non-CRC errors within host-to-device FIS
0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC
```