### PR TITLE
drivedb.h: Seagate Exos X18

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -4482,6 +4482,15 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
+  { "Seagate Exos X18",
+    // https://www.seagate.com/content/dam/seagate/migrated-assets/www-content/datasheets/pdfs/exos-x18-channel-DS2045-4-2106US-en_US.pdf
+    // tested with ST18000NM000J-2TV103/SN02
+    "ST1[02468]000NM0(0[01457]J|(1[3468]|20)G)-.*",
+    "", "",
+    "-v 18,raw48,Head_Health "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
   // new models: ST8000VN0002, ST6000VN0021, ST4000VN000
   //             ST8000VN0012, ST6000VN0031, ST4000VN003
   // tested with ST8000VN0002-1Z8112/ZA13YGNF


### PR DESCRIPTION
Output from `smartctl -x` already available in [ticket #1552](https://www.smartmontools.org/ticket/1552) (and also in duplicate [ticket #1566](https://www.smartmontools.org/ticket/1566)).

Tested with ST18000NM000J-2TV103/SN02.

Adds all models listed in [the datasheet](https://www.seagate.com/content/dam/seagate/migrated-assets/www-content/datasheets/pdfs/exos-x18-channel-DS2045-4-2106US-en_US.pdf):

- ST18000NM000J
- ST18000NM004J
- ST16000NM000J
- ST16000NM004J
- ST14000NM000J
- ST18000NM001J
- ST18000NM005J
- ST16000NM001J
- ST16000NM005J
- ST14000NM001J
- ST18000NM007J
- ST16000NM007J
- ST14000NM004J
- ST12000NM000J
- ST12000NM004J
- ST10000NM018G
- ST10000NM013G
- ST14000NM005J
- ST12000NM001J
- ST12000NM005J
- ST10000NM020G
- ST10000NM014G
- ST14000NM007J
- ST12000NM007J
- ST10000NM016G
