### PR TITLE
Update drivedb.h to add definitions for Pinas SATA Bridges

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -6597,6 +6597,23 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // Pinas 1
+  { "USB: ; Pinas sata",
+    "0x1741:0x1156", // 0x1741 Pinas USB 3.0 to IDE & SATA Adapter
+      // 0x471:0x1156  Pinas sata
+    "",
+    "",
+    "-d sat"
+  },
+  // Pinas 2
+  { "USB: ; Pinas SATA",
+    "0x174e:0x1155", // 0x174e Pinas USB 3.0 to IDE & SATA Adapter
+      // 0x174e:0x1155  Pinas  SATA id
+    "",
+    "",
+    "-d sat"
+  },
+
 /*
 }; // builtin_knowndrives[]
  */


### PR DESCRIPTION
Added definitions for 2 Pinas USB SATA bridges. These are used in the Argon Eon Pi NAS enclosure. (https://argon40.com/products/argon-eon-pi-nas)

For some reason the names differ from lower case to upper case, meaning there is no easy catch-all based on name.

The definitions are:

|Name|idVendor|idProduct|
|---|---|---|
|Pinas SATA|174e|1155|
|Pinas sata|1741|1156|

Hope this helps users like myself who use Openmediavault on the Argon Eon and would like to keep track of the drive temps.