### PR TITLE
drivedb.h: Add Sabrent EC-U2SA USB->SATA adapter support.

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -5957,6 +5957,12 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   // Realtek
+  { "USB: ; Sabrent EC-U2SA", // USB3->SATA
+    "0x0bda:0x9210", // Realtek RTL9210
+    "0x2001",
+    "",
+    "-d sat"
+  },
   { "USB: ; Realtek RTL9210", // USB->PCIe (NVMe)
     "0x0bda:0x9210",
     "", // 0x2100


### PR DESCRIPTION
The Sabrent EC-U2SA USB->SATA adapter uses a Realtek RTL9210 bridge.

This causes any attached SATA drive to be misidentified as NVME device:

```
% sudo smartctl -i /dev/da0
smartctl 7.2 2021-09-14 r5236 [FreeBSD 13.1-RELEASE-p9 amd64] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

Read NVMe Identify Controller failed: scsi error unsupported scsi opcode
```

The device identifies as a Realtek RTL9210 but uses a `bcdDevice` value of `0x2001`:

```
% sudo usbconfig -d 0.2 dump_device_desc
ugen0.2: <Realtek B USB Drive> at usbus0, cfg=0 md=HOST spd=SUPER (5.0Gbps) pwr=ON (224mA)

  bLength = 0x0012 
  bDescriptorType = 0x0001 
  bcdUSB = 0x0320 
  bDeviceClass = 0x0000  <Probed by interface class>
  bDeviceSubClass = 0x0000 
  bDeviceProtocol = 0x0000 
  bMaxPacketSize0 = 0x0009 
  idVendor = 0x0bda 
  idProduct = 0x9210 
  bcdDevice = 0x2001 
  iManufacturer = 0x0001  <Realtek>
  iProduct = 0x0002  <B USB Drive>
  iSerialNumber = 0x0003  <012345678918>
  bNumConfigurations = 0x0001 

```

I can manually override with `-d sat`:

```
% sudo smartctl -d sat -i /dev/da0
smartctl 7.2 2021-09-14 r5236 [FreeBSD 13.1-RELEASE-p9 amd64] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     WDC WD101EFAX-68LDBN0
Serial Number:    ********
LU WWN Device Id: 5 000cca 0b0d0215f
Firmware Version: 81.00A81
User Capacity:    10,000,831,348,736 bytes [10.0 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    5400 rpm
Form Factor:      3.5 inches
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   ACS-2, ATA8-ACS T13/1699-D revision 4
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Sun Mar 31 18:20:12 2024 PDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

```

This patch will identify any RTL9210 with a `bcdDevice` of `0x2001` as one of these adapters and set `-d sat` automatically.