### PR TITLE
Support for nvme per namespace smart

### DIFF
--- a/smartmontools/dev_interface.h
+++ b/smartmontools/dev_interface.h
@@ -711,6 +711,14 @@ public:
   unsigned get_nsid() const
     { return m_nsid; }
 
+  /// Get per namespace smart support.
+  bool get_suport_smart_per_ns() const
+    { return m_support_smart_per_ns; }
+
+  /// Set per namespace smart support.
+  void set_smart_per_ns(bool support)
+    { m_support_smart_per_ns = support; }
+
 protected:
   /// Hide/unhide NVMe interface.
   void hide_nvme(bool hide = true)
@@ -719,7 +727,8 @@ protected:
   /// Constructor requires namespace ID, registers device as NVMe.
   explicit nvme_device(unsigned nsid)
     : smart_device(never_called),
-      m_nsid(nsid)
+      m_nsid(nsid),
+      m_support_smart_per_ns(false)
     { hide_nvme(false); }
 
   /// Set namespace id.
@@ -733,6 +742,7 @@ protected:
 
 private:
   unsigned m_nsid;
+  bool m_support_smart_per_ns;
 };
 
 

--- a/smartmontools/nvmecmds.cpp
+++ b/smartmontools/nvmecmds.cpp
@@ -253,7 +253,9 @@ unsigned nvme_read_error_log(nvme_device * device, nvme_error_log_page * error_l
 // Read NVMe SMART/Health Information log.
 bool nvme_read_smart_log(nvme_device * device, nvme_smart_log & smart_log)
 {
-  if (!nvme_read_log_page_1(device, 0xffffffff, 0x02, &smart_log, sizeof(smart_log)))
+  unsigned nsid = device->get_suport_smart_per_ns() ? device->get_nsid() : 0xffffffff;
+
+  if (!nvme_read_log_page_1(device, nsid, 0x02, &smart_log, sizeof(smart_log)))
     return false;
 
   if (isbigendian()) {

--- a/smartmontools/nvmeprint.cpp
+++ b/smartmontools/nvmeprint.cpp
@@ -670,6 +670,8 @@ int nvmePrintMain(nvme_device * device, const nvme_print_options & options)
     return FAILID;
   }
 
+  device->set_smart_per_ns(id_ctrl.lpa & 0x1);
+
   // Print Identify Controller/Namespace info
   if (options.drive_info || options.drive_capabilities) {
     pout("=== START OF INFORMATION SECTION ===\n");

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -2774,6 +2774,7 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
     CloseDevice(nvmedev, name);
     return 2;
   }
+  nvmedev->set_smart_per_ns(id_ctrl.lpa & 0x1);
 
   // Get drive identity
   char model[40+1], serial[20+1], firmware[8+1];


### PR DESCRIPTION
use a proper nsid instad of `0xffffffff` for nvme devices that support the SMART log page on a per namespace basis.