### PR TITLE
Extend WMI timeout

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -3,7 +3,7 @@ $Id$
 2024-11-20  Eaton Zveare  <eaton@eaton-works.com>
 
 	Increase WMI timeout on Windows to address issues when
-        reading USB device ID.
+	reading USB device ID.
 
 	(GH pull/277)
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2024-11-20  Eaton Zveare  <eaton@eaton-works.com>
+
+	Increase WMI timeout on Windows to address issues when
+        reading USB device ID.
+
+	(GH pull/277)
+
 2024-11-20  Robin Schneider  <ypid@riseup.net>
 
 	man pages: Fix typo, '-l directory,q' was mentioned but only

--- a/smartmontools/os_win32/wmiquery.cpp
+++ b/smartmontools/os_win32/wmiquery.cpp
@@ -79,7 +79,7 @@ bool wbem_enumerator::next(wbem_object & obj)
     return false;
 
   ULONG n = 0;
-  HRESULT rc = m_intf->Next(5000 /*5s*/, 1 /*count*/, obj.m_intf.replace(), &n);
+  HRESULT rc = m_intf->Next(WBEM_INFINITE, 1 /*count*/, obj.m_intf.replace(), &n);
   if (FAILED(rc) || n != 1)
     return false;
   return true;

--- a/smartmontools/os_win32/wmiquery.cpp
+++ b/smartmontools/os_win32/wmiquery.cpp
@@ -79,7 +79,7 @@ bool wbem_enumerator::next(wbem_object & obj)
     return false;
 
   ULONG n = 0;
-  HRESULT rc = m_intf->Next(WBEM_INFINITE, 1 /*count*/, obj.m_intf.replace(), &n);
+  HRESULT rc = m_intf->Next(60000, 1 /*count*/, obj.m_intf.replace(), &n);
   if (FAILED(rc) || n != 1)
     return false;
   return true;


### PR DESCRIPTION
I recently ran into a problem with a user where they were getting an "Unable to read USB device ID" error message. After digging into it with them, I discovered a problem with the way smartctl uses WMI.

The WMI query in this case was returning `WBEM_S_TIMEDOUT`, which is a [non-error](https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmi-non-error-constants). I considered adding a check for this error so that it would not blow up the entire operation, but decided to instead raise the timeout. I chose the maximum value because that is what [Microsoft has for their default](https://learn.microsoft.com/en-us/dotnet/api/system.management.managementoptions.timeout#property-value).

This change resolves the issue for the user and should also help many other users as well.