### PR TITLE
farmprint.cpp: fix SATA decode of dateOfAssembly and uninitialized string

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2024-09-29  Ru Wang  <ru.wang@seagate.com>
+
+	farmprint.cpp:
+	- Fix SATA decode of dateOfAssembly.
+	- Uninitialized string (part from GH issues/272).
+
 2024-09-23  Christian Franke  <franke@computer.org>
 
 	os_win32.cpp: Decode Windows 11 23H2 and 24H2 build numbers.

--- a/smartmontools/farmprint.cpp
+++ b/smartmontools/farmprint.cpp
@@ -173,6 +173,7 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   farm_format_id_string(firmwareRev, farm_byte_swap(farmLog.driveInformation.firmwareRev2), farm_byte_swap(farmLog.driveInformation.firmwareRev));
 
   char modelNumber[sizeof(farmLog.driveInformation.modelNumber) + 1];
+  modelNumber[0] = '\0';
   for (uint8_t i = 0; i < sizeof(farmLog.driveInformation.modelNumber) / sizeof(farmLog.driveInformation.modelNumber[0]); i++) {
     farm_format_id_string(&modelNumber[strlen(modelNumber)], farm_byte_swap(farmLog.driveInformation.modelNumber[i]));
   }
@@ -180,7 +181,7 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   const char* recordingType = farm_get_recording_type(farmLog.driveInformation.driveRecordingType);
 
   char dateOfAssembly[sizeof(farmLog.driveInformation.dateOfAssembly)];
-  farm_format_id_string(dateOfAssembly, farm_byte_swap(farmLog.driveInformation.dateOfAssembly));
+  memcpy(dateOfAssembly, &farmLog.driveInformation.dateOfAssembly, sizeof(farmLog.driveInformation.dateOfAssembly));
 
   // Print plain-text
   jout("Seagate Field Access Reliability Metrics log (FARM) (GP Log 0xa6)\n");


### PR DESCRIPTION
This PR contains two fixes:

1. for SATA, dateOfAssembly is not properly decoded. It's YYWW which does not follow ATA string convention.
2. issue #272 mentions a static analysis issue of uninitialized string and is now fixed in this PR.