### PR TITLE
nvmeprint.cpp: Fix self-test for devices with multiple namespaces

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2024-10-23  Ameer Hamza  <ahamza@ixsystems.com>
+
+	nvmeprint.cpp: fix self-test for devices with multiple namespaces.
+	Use broadcast NSID for (06h) log page access to prevent `Invalid
+	Field in Command` error when accessing the log page. Also, use
+	device NSID for both single and multi namespace devices when
+	issuing the Device Self-test (14h) command.
+
 2024-09-23  Christian Franke  <franke@computer.org>
 
 	os_win32.cpp: Decode Windows 11 23H2 and 24H2 build numbers.


### PR DESCRIPTION
According to the NVMe specs, the 06h log page has only Controller and NVM Subsystem operation scopes, but not a namespace. Attempting to read this log page with a specific device NSID results in an `Invalid Field in Command` error.
This issue was previously resolved for single-namespace devices by using the broadcast NSID. However, the problem persists for devices with multiple namespaces, where the log page is still being accessed with a device-specific NSID. This fix ensures that the broadcast NSID is always used when reading the 06h log page.