### PR TITLE
drivedb.h: Add "HUS724045ALE640"

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3754,8 +3754,8 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Hitachi/HGST Ultrastar 7K4000", // tested with Hitachi HUS724040ALE640/MJAOA3B0,
       // HGST HUS724040ALE640/MJAOA580, HGST HUS724020ALA640/MF6OAA70,
-      // HUS724030ALA640/MF8OAAZ0
-    "(Hitachi |HGST )?HUS7240(20|30|40)AL[AE]64[01]",
+      // HUS724030ALA640/MF8OAAZ0, HGST HUS724045ALE640/MJBOA5G0
+    "(Hitachi |HGST )?HUS7240(20|30|40|45)AL[AE]64[01]",
     "", "", ""
   },
   { "Hitachi/HGST Ultrastar 7K2",


### PR DESCRIPTION
This adds a new model HUS724045ALE640 to the Ultrastar 7K4000 database. This is a more obscure SKU that is not shown on the data sheet, but does actually exist and has been tested to show up without a database entry.

[smartctl's output of the drive.](https://github.com/user-attachments/files/18056209/output.txt)

Note that the output was taken over a USB bridge using `smartctl -a -x -d sat,12 /dev/sdb`. I can also provide output over native SATA, if needed.