### PR TITLE
dev_jmb39x_raid.cpp: support QNAP-TR002 NAS

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2024-12-10  Rodrigo Araujo  <araujo.rm@gmail.com>
+
+	dev_jmb39x_raid.cpp: support QNAP-TR002 NAS
+
+	Add '-d jmb39x-q2,...' device type for JMB39x
+	protocol variant used by QNAP-TR002 NAS.
+	(#1290, GH pull/306)
+
 2024-11-30  Christian Franke  <franke@computer.org>
 
 	os_win32.cpp: Decode Windows Server 2025 build number.

--- a/smartmontools/dev_interface.cpp
+++ b/smartmontools/dev_interface.cpp
@@ -306,7 +306,7 @@ std::string smart_interface::get_valid_dev_types_str()
   std::string s =
     "ata, scsi[+TYPE], nvme[,NSID], sat[,auto][,N][+TYPE], usbasm1352r,N, usbcypress[,X], "
     "usbjmicron[,p][,x][,N], usbprolific, usbsunplus, sntasmedia, sntjmicron[,NSID], "
-    "sntrealtek, jmb39x[-q],N[,sLBA][,force][+TYPE], "
+    "sntrealtek, jmb39x[-q[2]],N[,sLBA][,force][+TYPE], "
     "jms56x,N[,sLBA][,force][+TYPE]";
   // append custom
   std::string s2 = get_valid_custom_dev_types_str();

--- a/smartmontools/dev_jmb39x_raid.cpp
+++ b/smartmontools/dev_jmb39x_raid.cpp
@@ -179,7 +179,9 @@ static void jmb_set_request_sector(uint8_t (& data)[512], uint8_t version, uint3
   switch (version) {
     default:
     case 0: scrambled_cmd_code = 0x197b0322; break; // JMB39x: various devices
-    case 1: scrambled_cmd_code = 0x197b0393; break; // JMB39x: QNAP TR-004 NAS
+    case 1:                                         // JMB39x: QNAP TR-004 NAS
+    case 3:                                         // JMB39x: QNAP TR-002 NAS
+            scrambled_cmd_code = 0x197b0393; break;
     case 2: scrambled_cmd_code = 0x197b0562; break; // JMS562
   }
   jmb_put_le32(data, 0, scrambled_cmd_code);
@@ -704,6 +706,8 @@ ata_device * smart_interface::get_jmb39x_device(const char * type, smart_device 
     version = 1;
   else if (!strcmp(prefix, "jms56x"))
     version = 2;
+  else if (!strcmp(prefix, "jmb39x-q2"))
+    version = 3;
   else
     n1 = -1;
   if (n1 < 0) {


### PR DESCRIPTION
Add '-d jmb39x-q2,...' device type for JMB39x
protocol variant used by QNAP-TR002 NAS.

Fixes https://www.smartmontools.org/ticket/1290

The difference between the QNAP-TR002 and the existing QNAP-TR004 is minimal. Using the same `scrambled_cmd_code` but using 0x2 as the "version" byte like the other variants, instead of 0x1, it works.

In this patch a new variant jmb39x-q2 is introduced to deal with the (small, but 4 years unresolved) difference. Feel free to request another nomenclature for the new variant, as well as any other modification you deem necessary.

Sample output (tested on Raspberry Pi 5 connected to a new TR-002 with latest firmware, RAID 1 set by dip switches):
```
# smartctl-q2 -a -d jmb39x-q2,0 /dev/sda
smartctl pre-7.5 2024-12-06 r5643 [aarch64-linux-6.6.62+rpt-rpi-2712] (local build)
Copyright (C) 2002-24, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Western Digital Red (CMR)
Device Model:     WDC WD40EFPX-68C6CN0
Serial Number:    WD-WX<secure_cut>66
LU WWN Device Id: 5 0014ee 26adb463a
Firmware Version: 81.00A81
User Capacity:    4,000,787,030,016 bytes [4.00 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    5400 rpm
Form Factor:      3.5 inches
Device is:        In smartctl database
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Tue Dec 10 00:21:16 2024 WET
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
(...)

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x002f   200   200   051    Pre-fail  Always       -       0
  3 Spin_Up_Time            0x0027   211   211   021    Pre-fail  Always       -       2433
  4 Start_Stop_Count        0x0032   100   100   000    Old_age   Always       -       7
  5 Reallocated_Sector_Ct   0x0033   200   200   140    Pre-fail  Always       -       0
  7 Seek_Error_Rate         0x002e   100   253   000    Old_age   Always       -       0
  9 Power_On_Hours          0x0032   100   100   000    Old_age   Always       -       4
 10 Spin_Retry_Count        0x0032   100   253   000    Old_age   Always       -       0
 11 Calibration_Retry_Count 0x0032   100   253   000    Old_age   Always       -       0
 12 Power_Cycle_Count       0x0032   100   100   000    Old_age   Always       -       1
192 Power-Off_Retract_Count 0x0032   200   200   000    Old_age   Always       -       0
193 Load_Cycle_Count        0x0032   200   200   000    Old_age   Always       -       10
194 Temperature_Celsius     0x0022   115   112   000    Old_age   Always       -       32
196 Reallocated_Event_Count 0x0032   200   200   000    Old_age   Always       -       0
197 Current_Pending_Sector  0x0032   200   200   000    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0030   100   253   000    Old_age   Offline      -       0
199 UDMA_CRC_Error_Count    0x0032   200   200   000    Old_age   Always       -       0
200 Multi_Zone_Error_Rate   0x0008   100   253   000    Old_age   Offline      -       0

SMART Error Log Version: 1
No Errors Logged

Read SMART Self-test Log failed: ATA command not implemented due to truncated response [JMB39x]

Read SMART Selective Self-test Log failed: ATA command not implemented due to truncated response [JMB39x]

The above only provides legacy SMART information - try 'smartctl -x' for more
```

whereas if one tests the other disk one can see it working as expected in my setup (a disk of same brand with different S/N and some different and correct reported counters):
```
# smartctl-q2 -a -d jmb39x-q2,1 /dev/sda
smartctl pre-7.5 2024-12-06 r5643 [aarch64-linux-6.6.62+rpt-rpi-2712] (local build)
Copyright (C) 2002-24, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Western Digital Red (CMR)
Device Model:     WDC WD40EFPX-68C6CN0
Serial Number:    WD-WX<secure_cut>YK
(...)

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x002f   100   253   051    Pre-fail  Always       -       0
  3 Spin_Up_Time            0x0027   203   203   021    Pre-fail  Always       -       2850
  4 Start_Stop_Count        0x0032   100   100   000    Old_age   Always       -       10
  5 Reallocated_Sector_Ct   0x0033   200   200   140    Pre-fail  Always       -       0
  7 Seek_Error_Rate         0x002e   200   200   000    Old_age   Always       -       0
  9 Power_On_Hours          0x0032   100   100   000    Old_age   Always       -       4
 10 Spin_Retry_Count        0x0032   100   253   000    Old_age   Always       -       0
 11 Calibration_Retry_Count 0x0032   100   253   000    Old_age   Always       -       0
 12 Power_Cycle_Count       0x0032   100   100   000    Old_age   Always       -       9
192 Power-Off_Retract_Count 0x0032   200   200   000    Old_age   Always       -       2
193 Load_Cycle_Count        0x0032   200   200   000    Old_age   Always       -       9
194 Temperature_Celsius     0x0022   115   113   000    Old_age   Always       -       32
196 Reallocated_Event_Count 0x0032   200   200   000    Old_age   Always       -       0
197 Current_Pending_Sector  0x0032   200   200   000    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0030   100   253   000    Old_age   Offline      -       0
199 UDMA_CRC_Error_Count    0x0032   200   200   000    Old_age   Always       -       0
200 Multi_Zone_Error_Rate   0x0008   100   253   000    Old_age   Offline      -       0

SMART Error Log Version: 1
No Errors Logged

Read SMART Self-test Log failed: ATA command not implemented due to truncated response [JMB39x]

Read SMART Selective Self-test Log failed: ATA command not implemented due to truncated response [JMB39x]

The above only provides legacy SMART information - try 'smartctl -x' for more
```