### PR TITLE
drivedb.h: add Bufallo SSD-PSTA/N (0x0411:0x039d)

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -5422,6 +5422,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  { "USB: Buffalo SSD-PSTA/N; ",
+    "0x0411:0x039d",
+    "",
+    "",
+    "-d sntasmedia"
+  },
   // LG Electronics
   { "USB: LG Mini HXD5; JMicron",
     "0x043e:0x70f1",


### PR DESCRIPTION
This adds support for the Buffalo SSD-PST1.0U3BA/N, a USB SSD drive utilizing the ASMedia chipset.

`smartctl` output:
```
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.8.12-4-pve] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       SSD-PSTA/N
Serial Number:                      0020696031110463
Firmware Version:                   UHFM00.6
PCI Vendor/Subsystem ID:            0x0000
IEEE OUI Identifier:                0x000000
Controller ID:                      0
NVMe Version:                       <1.2
Number of Namespaces:               0
Local Time is:                      Wed Dec 11 01:16:17 2024 CET
Firmware Updates (0x00):            0 Slots

Supported Power States
St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
 0 +     0.00W       -        -    0  0  0  0        0       0

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02)
Critical Warning:                   0x00
Temperature:                        58 Celsius
Available Spare:                    100%
Available Spare Threshold:          50%
Percentage Used:                    0%
Data Units Read:                    43,912 [22.4 GB]
Data Units Written:                 219,839 [112 GB]
Host Read Commands:                 0
Host Write Commands:                0
Controller Busy Time:               0
Power Cycles:                       36
Power On Hours:                     143
Unsafe Shutdowns:                   34
Media and Data Integrity Errors:    0
Error Information Log Entries:      0

Error Information (NVMe Log 0x01, 1 of 1 entries)
Num   ErrCount  SQId   CmdId  Status  PELoc          LBA  NSID    VS
  0 216426171136     0  0x0000  0x0000  0x000            0     0     -
```
