### PR TITLE
Silence "Referenced but unset environment variable" warning

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-01-23  Andrew Sayers <andrew-github.com@pileofstuff.org>
+
+	smartd.service: silence "Referenced but unset environment variable" warning
+
 2025-01-15  Oleksii Samorukov <samm@os2.kiev.ua>
 
 	sntjmicron: workaround to avoid USB reset on selftest log query (GH: #256).

--- a/smartmontools/smartd.service.in
+++ b/smartmontools/smartd.service.in
@@ -8,6 +8,7 @@ ConditionVirtualization=no
 
 [Service]
 Type=notify
+Environment=smartd_opts=''
 EnvironmentFile=-/usr/local/etc/sysconfig/smartmontools
 ExecStart=/usr/local/sbin/smartd -n $smartd_opts
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Systemd v254+ warns about unset environment variables, so we need to provide an explicit default value.

Based on https://github.com/analogdevicesinc/libiio/pull/1144