### PR TITLE
Support Swissbit X-7x, X-8x family.

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2025-02-25  Daniel SWB  <daniel.swb.gh@gmail.com>
+
+	drivedb.h:
+	- Swissbit X-7x, X-8x family SATA SSD
+
+	(GH pull/322)
+
 2025-02-15  Christian Franke  <franke@computer.org>
 
 	ataprint.cpp: Add support for '-l farm -T permissive'.

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -200,6 +200,65 @@ const drive_settings builtin_knowndrives[] = {
     "-v 248,raw48,Perc_Rated_Life_Remain "
     "-v 249,raw48,Spares_Remaining_Perc "
   },
+  { "Swissbit X-7x Family SATA SSD",
+    "SFSA....(S|Q|M|U|V).AK.T(A|B|O).............",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 16,raw48,Avg_Erase_Count_pSLC "
+    "-v 17,raw48,Rated_Erase_Count_pSLC "
+    "-v 160,raw48,UECC_Sector_Count "
+    "-v 161,raw48,Spare_Block_Count "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 166,raw48,Minimum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_UECC_Err_Cnt "
+    "-v 193,raw48,Dynamic_Remaps "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 215,raw48,Number_of_TRIM_Commands  "
+    "-v 231,raw48,Life_Remaining_Percent "
+    "-v 235,raw48,Flash_LBAs_Written "
+    "-v 237,raw48,Flash_LBAs_Written_Exp "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 243,raw48,Host_LBA_Write_Exp "
+    "-v 244,raw48,Host_LBA_Read_Exp "
+    "-v 248,raw48,SSD_Remaining_Life_Perc "
+  },
+  { "Swissbit X-8x Family SATA SSD",
+    "SFSA....M.AO.TO.............",
+    "", "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_Data_Repairs "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 185,raw48,E2E_ErrCnt_SATA-Flash "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 196,raw48,Total_Spare_Block_Cnt "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 200,raw48,SATA_COM_Reset "
+    "-v 213,raw48,Spare_Block_Cnt_Worst  "
+    "-v 215,raw48,Trim_Status  "
+    "-v 229,raw48,Total_Flash_Block_Erases  "
+    "-v 232,raw48,Total_Read_Cnt "
+    "-v 241,raw48,Total_Host_LBA_Written "
+    "-v 242,raw48,Total_Host_LBA_Read "
+    "-v 248,raw48,Remaining_Life "
+  },
   { "Apacer SDM4 Series SSD Module",
     "(2|4|8|16|32|64)GB SATA Flash Drive", // tested with APSDM002G15AN-CT/SFDDA01C and SFI2101D
     "SF(DDA01C|I2101D)",


### PR DESCRIPTION
smartctl -x /dev/sdX output
```
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.8.0-41-generic] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     SFSA060GM2AK1TO-C-6B-536-STD
Serial Number:    0000602260449A00001D
Firmware Version: SBR11007
User Capacity:    60,022,480,896 bytes [60.0 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        Not in smartctl database 7.3/5660
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Mon Feb 17 15:27:59 2025 CST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]
Write SCT (Get) Feature Control Command failed: scsi error badly formed scsi parameters
Wt Cache Reorder: Unknown (SCT Feature Control command failed)

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x02)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x53) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					No Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  15) minutes.
SCT capabilities: 	       (0x0031)	SCT Status supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     PO-R--   100   100   000    -    0
  5 Reallocated_Sector_Ct   PO--C-   100   100   000    -    0
  9 Power_On_Hours          -O--C-   100   100   000    -    6
 12 Power_Cycle_Count       -O--C-   100   100   000    -    25
 16 Unknown_Attribute       -O--C-+  100   100   001    -    58
 17 Unknown_Attribute       -O--C-   100   100   000    -    30000
160 Unknown_Attribute       -O----   100   100   000    -    0
161 Unknown_Attribute       -O--C-   100   100   000    -    6291552
163 Unknown_Attribute       PO----   100   100   000    -    5
164 Unknown_Attribute       -O--C-   100   100   000    -    2369
165 Unknown_Attribute       -O----   100   100   000    -    2
166 Unknown_Attribute       -O--C-   100   100   000    -    0
167 Unknown_Attribute       -O--C-   100   100   000    -    1
168 Unknown_Attribute       -O--C-   100   100   000    -    3000
169 Unknown_Attribute       PO----   100   100   000    -    15
193 Unknown_SSD_Attribute   -O--C-   100   100   000    -    0
194 Temperature_Celsius     PO---K   100   100   000    -    34 (Min/Max 20/57)
195 Hardware_ECC_Recovered  -O--C-   100   100   000    -    2
196 Reallocated_Event_Count -O--C-   000   000   000    -    0
198 Offline_Uncorrectable   -O--C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    PO-R--   100   100   000    -    0
215 Unknown_Attribute       -O--C-   100   100   000    -    145
231 Unknown_SSD_Attribute   PO--C-+  100   100   025    -    429496729700
235 Unknown_Attribute       -O--C-   100   100   000    -    232978560
237 Unknown_Attribute       -O--C-   100   100   000    -    0
241 Total_LBAs_Written      -O--C-   100   100   000    -    235622634
242 Total_LBAs_Read         -O--C-   100   100   000    -    124062293
243 Unknown_Attribute       -O--C-   100   100   000    -    0
244 Unknown_Attribute       -O--C-   100   100   000    -    0
248 Unknown_Attribute       -O--C-+  100   100   001    -    429496729700
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01       GPL,SL  R/O      1  Summary SMART error log
0x02       GPL,SL  R/O      1  Comprehensive SMART error log
0x03       GPL,SL  R/O      1  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06       GPL,SL  R/O      1  SMART self-test log
0x07       GPL,SL  R/O      1  Extended self-test log
0x09       GPL,SL  R/W      1  Selective self-test log
0x10       GPL,SL  R/O      1  NCQ Command Error log
0x11       GPL,SL  R/O      1  SATA Phy Event Counters log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xdf       GPL,SL  VS       1  Device vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (1 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%         6         -

SMART Selective self-test log data structure revision number 1
 SPAN               MIN_LBA               MAX_LBA  CURRENT_TEST_STATUS
    1  13744689132276146914   3400214404550097144  Not_testing
    2  10055341420481838718  16348822766780505951  Not_testing
    3  17940277870617253719   9114980990832137685  Not_testing
    4   6872346224012293621   6293744052285193661  Not_testing
    5  15408423699605057391  17723262871068629851  Not_testing
46003   8753141046926561231   8753141046926626766  Read_scanning was completed without error
Selective self-test flags (0xbcbc):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 11308 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       0 (0x0000)
Device State:                        Active (0)
Current Temperature:                    35 Celsius
Power Cycle Min/Max Temperature:     23/57 Celsius
Lifetime    Min/Max Temperature:     20/57 Celsius
Under/Over Temperature Limit Count:   0/0

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      0/100 Celsius
Min/Max Temperature Limit:            0/100 Celsius
Temperature History Size (Index):    128 (50)

Index    Estimated Time   Temperature Celsius
  51    2025-02-17 13:20    31  ************
 ...    ..( 17 skipped).    ..  ************
  69    2025-02-17 13:38    31  ************
  70    2025-02-17 13:39    30  ***********
 ...    ..(  3 skipped).    ..  ***********
  74    2025-02-17 13:43    30  ***********
  75    2025-02-17 13:44    31  ************
  76    2025-02-17 13:45    30  ***********
 ...    ..(  3 skipped).    ..  ***********
  80    2025-02-17 13:49    30  ***********
  81    2025-02-17 13:50    31  ************
 ...    ..( 32 skipped).    ..  ************
 114    2025-02-17 14:23    31  ************
 115    2025-02-17 14:24    32  *************
 116    2025-02-17 14:25    31  ************
 ...    ..(  5 skipped).    ..  ************
 122    2025-02-17 14:31    31  ************
 123    2025-02-17 14:32    32  *************
 124    2025-02-17 14:33    31  ************
 ...    ..(  5 skipped).    ..  ************
   2    2025-02-17 14:39    31  ************
   3    2025-02-17 14:40    32  *************
   4    2025-02-17 14:41    31  ************
 ...    ..(  3 skipped).    ..  ************
   8    2025-02-17 14:45    31  ************
   9    2025-02-17 14:46    32  *************
  10    2025-02-17 14:47    31  ************
 ...    ..(  5 skipped).    ..  ************
  16    2025-02-17 14:53    31  ************
  17    2025-02-17 14:54    32  *************
  18    2025-02-17 14:55    31  ************
 ...    ..(  5 skipped).    ..  ************
  24    2025-02-17 15:01    31  ************
  25    2025-02-17 15:02    32  *************
  26    2025-02-17 15:03    31  ************
 ...    ..(  3 skipped).    ..  ************
  30    2025-02-17 15:07    31  ************
  31    2025-02-17 15:08    32  *************
  32    2025-02-17 15:09    31  ************
 ...    ..(  2 skipped).    ..  ************
  35    2025-02-17 15:12    31  ************
  36    2025-02-17 15:13    46  ***************************
 ...    ..(  2 skipped).    ..  ***************************
  39    2025-02-17 15:16    46  ***************************
  40    2025-02-17 15:17    57  **************************************
  41    2025-02-17 15:18    34  ***************
 ...    ..(  4 skipped).    ..  ***************
  46    2025-02-17 15:23    34  ***************
  47    2025-02-17 15:24    35  ****************
  48    2025-02-17 15:25    35  ****************
  49    2025-02-17 15:26    35  ****************
  50    2025-02-17 15:27    31  ************

SCT Error Recovery Control command not supported

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4              25  ---  Lifetime Power-On Resets
0x01  0x010  4               6  ---  Power-on Hours
0x01  0x018  6       235622634  ---  Logical Sectors Written
0x01  0x020  6          513528  ---  Number of Write Commands
0x01  0x028  6       124062293  ---  Logical Sectors Read
0x01  0x030  6          549621  ---  Number of Read Commands
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4              15  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              35  ---  Current Temperature
0x05  0x010  1               -  ---  Average Short Term Temperature
0x05  0x018  1               -  ---  Average Long Term Temperature
0x05  0x020  1              65  ---  Highest Temperature
0x05  0x028  1              50  ---  Lowest Temperature
0x05  0x030  1               -  ---  Highest Average Short Term Temperature
0x05  0x038  1               -  ---  Lowest Average Short Term Temperature
0x05  0x040  1               -  ---  Highest Average Long Term Temperature
0x05  0x048  1               -  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              85  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4              66  ---  Number of Hardware Resets
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            0  Command failed due to ICRC error
0x0005  2            0  R_ERR response for non-data FIS
0x000a  2            3  Device-to-host register FISes sent due to a COMRESET
```
![Swissbit_SMARTINFO_X7x](https://github.com/user-attachments/assets/39b66f02-297c-4f7b-bed6-3435a4098eb4)

Below is the result.

```
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.8.0-52-generic] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Swissbit X-7x Family SATA SSD
Device Model:     SFSA060GM2AK1TO-C-6B-536-STD
Serial Number:    0000602260449A00001D
Firmware Version: SBR11007
User Capacity:    60,022,480,896 bytes [60.0 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Feb 19 10:30:04 2025 CST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x53) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					No Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  15) minutes.
SCT capabilities: 	       (0x0031)	SCT Status supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000b   100   100   000    Pre-fail  Always       -       0
  5 Reallocated_Sector_Ct   0x0013   100   100   000    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0012   100   100   000    Old_age   Always       -       13
 12 Power_Cycle_Count       0x0012   100   100   000    Old_age   Always       -       27
 16 Avg_Erase_Count_pSLC    0x0112   100   100   001    Old_age   Always       -       58
 17 Rated_Erase_Count_pSLC  0x0012   100   100   000    Old_age   Always       -       30000
160 UECC_Sector_Count       0x0002   100   100   000    Old_age   Always       -       0
161 Spare_Block_Count       0x0012   100   100   000    Old_age   Always       -       6291552
163 Initial_Bad_Block_Count 0x0003   100   100   000    Pre-fail  Always       -       5
164 Total_Erase_Count       0x0012   100   100   000    Old_age   Always       -       2369
165 Maximum_Erase_Count     0x0002   100   100   000    Old_age   Always       -       2
166 Minimum_Erase_Count     0x0012   100   100   000    Old_age   Always       -       0
167 Average_Erase_Count     0x0012   100   100   000    Old_age   Always       -       1
168 Rated_Erase_Count       0x0012   100   100   000    Old_age   Always       -       3000
169 Power_On_UECC_Err_Cnt   0x0003   100   100   000    Pre-fail  Always       -       15
193 Dynamic_Remaps          0x0012   100   100   000    Old_age   Always       -       0
194 Temperature_Celsius     0x0023   100   100   000    Pre-fail  Always       -       25 (Min/Max 20/57)
195 Hardware_ECC_Recovered  0x0012   100   100   000    Old_age   Always       -       2
196 Reallocated_Event_Count 0x0012   000   000   000    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0012   100   100   000    Old_age   Always       -       0
199 UDMA_CRC_Error_Count    0x000b   100   100   000    Pre-fail  Always       -       0
215 Number_of_TRIM_Commands 0x0012   100   100   000    Old_age   Always       -       145
231 Life_Remaining_Percent  0x1913   100   100   025    Pre-fail  Always       -       429496729700
235 Flash_LBAs_Written      0x0012   100   100   000    Old_age   Always       -       232978560
237 Flash_LBAs_Written_Exp  0x0012   100   100   000    Old_age   Always       -       0
241 Total_LBAs_Written      0x0012   100   100   000    Old_age   Always       -       235622734
242 Total_LBAs_Read         0x0012   100   100   000    Old_age   Always       -       124202434
243 Host_LBA_Write_Exp      0x0012   100   100   000    Old_age   Always       -       0
244 Host_LBA_Read_Exp       0x0012   100   100   000    Old_age   Always       -       0
248 SSD_Remaining_Life_Perc 0x0112   100   100   001    Old_age   Always       -       429496729700

SMART Error Log Version: 1
No Errors Logged

SMART Self-test log structure revision number 1
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%         6         -

SMART Selective self-test log data structure revision number 1
 SPAN               MIN_LBA               MAX_LBA  CURRENT_TEST_STATUS
    1  13744689132276146914   3400214404550097144  Not_testing
    2  10055341420481838718  16348822766780505951  Not_testing
    3  17940277870617253719   9114980990832137685  Not_testing
    4   6872346224012293621   6293744052285193661  Not_testing
    5  15408423699605057391  17723262871068629851  Not_testing
46003   8753141046926561231   8753141046926626766  Read_scanning was never started
Selective self-test flags (0xbcbc):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 11308 minute delay.

The above only provides legacy SMART information - try 'smartctl -x' for more

```
