### PR TITLE
drivedb.h: add Realtek RTL9220 (0x0bda:0x9220)

### DIFF
--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,10 @@
 $Id$
 
+2025-03-04  Glucy2 <glucy-2@outlook.com>
+
+	drivedb.h: add Realtek RTL9220 (0x0bda:0x9220)
+	(GH pull/327)
+
 2025-02-24  Ross Lagerwall  <ross.lagerwall@citrix.com>
 
 	scsicmds.cpp:

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -6090,6 +6090,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "" // ... SATA (unsupported)
   },
+  { "USB: ; Realtek RTL9220", // USB->PCIe (NVMe) or SATA
+    "0x0bda:0x9220",
+    "",
+    "",
+    "-d sntrealtek" // ... SATA (requires `-d sat`)
+  },
   // Addonics
   { "USB: Addonics HDMU3; ", // (ticket #609)
     "0x0bf6:0x1001",


### PR DESCRIPTION
Realtek RTL9220 is a USB 3.2 Gen2x2 (20 Gbps) dual protocol (NVMe and SATA) bridge.
Add support for Realtek RTL9220 by using `-d sntrealtek` for NVMe drives, and it requires `-d sat` for SATA drives.
Tested on ArchLinux with NVMe and SATA drives:
```
smartctl pre-7.5 2025-02-24 r5664M [x86_64-linux-6.13.5-zen1-1-zen] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       KINGBANK KP230 Pro
Serial Number:                      xxxxxxxxxxxx
Firmware Version:                   SN10093
PCI Vendor/Subsystem ID:            0x1e4b
IEEE OUI Identifier:                0x3a5a27
Total NVM Capacity:                 1,024,209,543,168 [1.02 TB]
Unallocated NVM Capacity:           0
Controller ID:                      0
NVMe Version:                       1.4
Number of Namespaces:               1
Namespace 1 Size/Capacity:          1,024,209,543,168 [1.02 TB]
Namespace 1 Formatted LBA Size:     512
Namespace 1 IEEE EUI-64:            3a5a27 03aa00040f
Local Time is:                      Wed Mar  5 16:29:30 2025 +08
Firmware Updates (0x14):            2 Slots, no Reset required
Optional Admin Commands (0x0017):   Security Format Frmw_DL Self_Test
Optional NVM Commands (0x001f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat
Log Page Attributes (0x02):         Cmd_Eff_Lg
Maximum Data Transfer Size:         128 Pages
Warning  Comp. Temp. Threshold:     90 Celsius
Critical Comp. Temp. Threshold:     95 Celsius

...(more)
```
```
smartctl pre-7.5 2025-02-24 r5664M [x86_64-linux-6.13.5-zen1-1-zen] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     NGFF 2242 128GB SSD
Serial Number:    2022101800044
LU WWN Device Id: 0 000000 000000000
Firmware Version: FW201105
User Capacity:    128,035,676,160 bytes [128 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available
Device is:        Not in smartctl database
ATA Version is:   ACS-2 T13/2015-D revision 3
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Mar  5 16:42:55 2025 +08
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

...(more)
```

