### PR TITLE
Add support for Bluendless U23QC 2.5" external USB case

### DIFF
--- a/src/drivedb.h
+++ b/src/drivedb.h
@@ -5463,6 +5463,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // Blueendless
+  { "USB: Blueendless; Initio",
+    "0x0204:0x3639", // U23QC
+    "",
+    "",
+    "-d sat"
+  },
   // 0x0350 (?)
   { "USB: ViPowER USB3.0 Storage; ",
     "0x0350:0x0038",
@@ -6931,13 +6938,6 @@ const drive_settings builtin_knowndrives[] = {
   { "USB: ; ",
     "0xabcd:0x610[34]", // 0x6103: LogiLink AU0028A V1.0 USB 3.0 to IDE & SATA Adapter
       // 0x6104: LogiLink PCCloneEX Lite
-    "",
-    "",
-    "-d sat"
-  },
-  // Blueendless
-  { "USB: ; Blueendless",
-    "0x0204:0x3639", // U23QC
     "",
     "",
     "-d sat"


### PR DESCRIPTION
This adds support for [the Blueendless U23QC 2.5" external USB case](https://www.aliexpress.com/item/1005006059948618.html). The U23Q will probably work too but I can't test it.

Here's the output without the modification
```bash
/dev/...: Unknown USB bridge [0x0204:0x3639 (0x157)]
```

Here's the relevant `lsusb` and `lsusb -t` outputs.
```
Bus 003 Device 002: ID 0204:3639 Chipsbank Microelectronics Co., Ltd  Blueendless

|__ Port 1: Dev 2, If 0, Class=Mass Storage, Driver=uas, 5000M
    ID 0204:3639 Chipsbank Microelectronics Co., Ltd
```

[Here's the output of `smartctl -x /dev/...` after adding support](https://github.com/user-attachments/files/20557894/smart.txt).

I'm not sure how useful this is but here's pictures of the PCB.
![20250602_205836](https://github.com/user-attachments/assets/393259af-8733-485b-89da-e2e1234f56e2)
![20250602_205847](https://github.com/user-attachments/assets/0c16692f-fb92-441d-a302-00df509b9dd2)

This is my first contributioon to the project so please let me know if anything's wrong or if you need more information.