### PR TITLE
Create GHA for the smartmontools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,305 @@
+name: Build smartmontools (non-release)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  # job to create tar.gz tarball, used by other builders
+  make-src-tgz:
+    runs-on: ubuntu-latest
+    name: Create smartmontools dist
+    outputs:
+      SOURCE_DATE_EPOCH: ${{ steps.set-env.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ steps.set-env.outputs.SM_VER }}
+      SM_REV: ${{ steps.set-env.outputs.SM_REV }}
+      artficact-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setting environment variables
+      id: set-env
+      run: |
+        git log -1 --format="SOURCE_DATE_EPOCH=%at" >> $GITHUB_ENV
+        echo SM_VER=$(sed -n 's|^AC_INIT[^,]*, *\[\([0-9.]*\)\] *,.*$|\1|p' configure.ac) >> $GITHUB_ENV
+        echo SM_REV=$(git rev-parse --short=12 HEAD) >> $GITHUB_ENV
+        cat $GITHUB_ENV | tee $GITHUB_OUTPUT
+
+    - name: Creating src.tar.gz
+      run: |
+        ./autogen.sh --force &&
+        mkdir build && cd build &&
+        ../configure SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+        (make dist && tar -tvzf smartmontools-${SM_VER}.tar.gz) &&
+        mkdir artifacts &&
+        echo ${SOURCE_DATE_EPOCH} > artifacts/SOURCE_DATE_EPOCH &&
+        mv smartmontools-${SM_VER}.tar.gz artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz
+
+    - name: Upload artifacts
+      id: artifact-upload-step
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifacts
+        path: build/artifacts/
+        retention-days: 1
+
+  compile-linux-static-x86_64:
+    name: Creating static x86_64 linux binaries
+    needs: make-src-tgz
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.make-src-tgz.outputs.artficact-id }}      
+      - name: build
+        run: |
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} && mkdir build && cd build &&
+          ../configure LDFLAGS="-static" SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+          make -j BUILD_INFO='"(GHA Build)"' && make check &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts && make DESTDIR="$(pwd)/inst" install &&
+          cd inst &&
+          tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} -czf "${GITHUB_WORKSPACE}/artifacts/smartmontools-linux-x86_64-static-${SM_VER}-r${SM_REV}.tar.gz" *
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_static_x86_64
+          path: artifacts/smartmontools-linux-x86_64-static-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.tar.gz
+          retention-days: 1
+
+  compile-linux-static-i386:
+    name: Creating static i386 linux binaries
+    needs: make-src-tgz
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.make-src-tgz.outputs.artficact-id }}    
+      - name: install m32 dependencies
+        run: sudo apt-get install gcc-multilib g++-multilib
+      - name: build
+        run: |
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} && mkdir build && cd build &&
+          ../configure CC="gcc -m32" CXX="g++ -m32" LDFLAGS="-static" SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+          make -j BUILD_INFO='"(GHA Build)"' && make check &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts && make DESTDIR="$(pwd)/inst" install &&
+          cd inst &&
+          tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} -czf "${GITHUB_WORKSPACE}/artifacts/smartmontools-linux-i386-static-${SM_VER}-r${SM_REV}.tar.gz" *
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_static_i386
+          path: artifacts/smartmontools-linux-i386-static-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.tar.gz
+          retention-days: 1
+
+  compile-darwin:
+    name: Creating Darwin image
+    needs: make-src-tgz
+    runs-on: ubuntu-latest
+    # we are using clang/osxcross to build it, so running in container
+    # see smartmontools/docker-build for the source
+    container: 
+      image: ghcr.io/smartmontools/docker-build:master     
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.make-src-tgz.outputs.artficact-id }}
+      - name: build
+        run: |
+          export PATH=/usr/osxcross/bin/:$PATH &&
+          export LD_LIBRARY_PATH=/usr/osxcross/lib &&
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} &&
+          mkdir build && cd build &&
+          ../configure build_alias=$(../config.guess) host_alias=x86_64-apple-darwin14 \
+            'CC=o64-clang' 'CXX=o64-clang++' 'CFLAGS=-arch arm64 -arch x86_64' \
+            'CXXFLAGS=-arch arm64 -arch x86_64 -stdlib=libc++' \
+            '--sysconfdir=/private/etc' SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+          make -j BUILD_INFO='"(GHA Build)"' &&
+          make pkg_darwin=smartmontools-${SM_VER}-r${SM_REV}.pkg dmg_darwin=smartmontools-${SM_VER}-r${SM_REV}.dmg install-darwin &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts &&
+          mv ./src/smartmontools-${SM_VER}-r${SM_REV}.dmg ${GITHUB_WORKSPACE}/artifacts
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin
+          path: artifacts/smartmontools-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.dmg
+          retention-days: 1
+  
+  compile-freebsd:
+    name: Creating FreeBSD binaries
+    needs: make-src-tgz
+    runs-on: ubuntu-latest
+    # FreeBSD cross-compilation. We need to check, very possible it would be
+    # faster to do everything in normal runner, by installing things locally
+    # and using cache
+    container: 
+      image: ghcr.io/smartmontools/docker-build:master     
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.make-src-tgz.outputs.artficact-id }}
+      - name: FreeBSD 14 build
+        run: |
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} &&
+          mkdir build && cd build &&
+          export TARGET="-target x86_64-unknown-freebsd14 --sysroot=/opt/cross-freebsd-14/" &&
+          ../configure CC="clang $TARGET" CXX="clang++ $TARGET" \
+            CPPFLAGS="-isystem /opt/cross-freebsd-14/usr/include/c++/v1" \
+            LDFLAGS="-static" --host=x86_64-pc-freebsd14 \
+            SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+          make -j BUILD_INFO='"(GHA Build)"' &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts && make DESTDIR="$(pwd)/inst" install &&
+          cd inst &&
+          tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} -czf "${GITHUB_WORKSPACE}/artifacts/smartmontools-freebsd-14-${SM_VER}-r${SM_REV}.tar.gz" *
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd14
+          path: artifacts/smartmontools-freebsd-14-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.tar.gz
+          retention-days: 1
+      - name: cleanup
+        run: rm -rf smartmontools-${SM_VER}
+      - name: FreeBSD 13 build
+        run: |
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} &&
+          mkdir build && cd build &&
+          export TARGET="-target x86_64-unknown-freebsd13 --sysroot=/opt/cross-freebsd-13/" &&
+          ../configure CC="clang $TARGET" CXX="clang++ $TARGET" \
+            CPPFLAGS="-isystem /opt/cross-freebsd-13/usr/include/c++/v1" \
+            LDFLAGS="-static" --host=x86_64-pc-freebsd13 \
+            SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} &&
+          make -j BUILD_INFO='"(GHA Build)"' &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts && make DESTDIR="$(pwd)/inst" install &&
+          cd inst &&
+          tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} -czf "${GITHUB_WORKSPACE}/artifacts/smartmontools-freebsd-13-${SM_VER}-r${SM_REV}.tar.gz" *
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd13
+          path: artifacts/smartmontools-freebsd-13-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.tar.gz
+          retention-days: 1
+
+  compile-windows:
+    name: Creating Windows binary
+    needs: make-src-tgz
+    runs-on: ubuntu-latest
+    # windows cross-compilation, also running using our build container
+    # based on Debian 12. Probably could be migrated to normal ubuntu runner
+    # need to test this
+    container: 
+      image: ghcr.io/smartmontools/docker-build:master     
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.make-src-tgz.outputs.artficact-id }}
+      - name: Windows build
+        run: |
+          tar -xvf artifacts/smartmontools-${SM_VER}-r${SM_REV}.tar.gz &&
+          cd smartmontools-${SM_VER} &&
+          mkdir build && cd build &&
+          ../configure build_alias=$(../config.guess) host_alias=i686-w64-mingw32 \
+            SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+          make -j BUILD_INFO='"(GHA Build)"' && make distdir-win32 &&
+          cd .. && mkdir build64 && cd build64 &&
+          ../configure build_alias=$(../config.guess) host_alias=x86_64-w64-mingw32 \
+            SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} 
+          make -j  BUILD_INFO='"(GHA Build)"' && make distdir-win32 &&
+          cd ../build &&
+          dest="smartmontools-win32-setup-${SM_VER}-r${SM_REV}.exe" && \
+            make BUILD_INFO="$BUILD_INFO" builddir_win64=../../build64/src distinst_win32="$dest" installer-win32 &&
+          mkdir -p inst ${GITHUB_WORKSPACE}/artifacts && make DESTDIR="$(pwd)/inst" install &&
+          mv ./src/smartmontools-win32-setup-${SM_VER}-r${SM_REV}.exe ${GITHUB_WORKSPACE}/artifacts
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: artifacts/smartmontools-win32-setup-${{ needs.make-src-tgz.outputs.SM_VER }}-r${{ needs.make-src-tgz.outputs.SM_REV }}.exe
+          retention-days: 1
+
+
+  publish-artifacts:
+    # finally we are publishing all artifacts to the smartmontools/smartmontools-builds
+    # git repository on releases page
+    # Publishing should be performed only on main branch
+    if: github.ref == 'refs/heads/main'
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.make-src-tgz.outputs.SOURCE_DATE_EPOCH }}
+      SM_VER: ${{ needs.make-src-tgz.outputs.SM_VER }}
+      SM_REV: ${{ needs.make-src-tgz.outputs.SM_REV }}      
+    name: publish-artifacts
+    # we need to check how to make it conditional, to not fail if any of these
+    # failed
+    needs: 
+      - make-src-tgz
+      - compile-linux-static-x86_64
+      - compile-linux-static-i386
+      - compile-darwin
+      - compile-freebsd
+      - compile-windows
+    runs-on: ubuntu-latest
+    # we are using environment to store APP_ID/PRIVATE_KEY
+    environment: 
+      name: mainbranch
+      url: https://github.com/smartmontools/smartmontools-builds
+    steps:
+      - uses: actions/download-artifact@v4
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: smartmontools
+          repositories: smartmontools-builds
+      - name: gh create delete (clenup)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        # cleanup release with the same name
+        run: |
+          gh release delete r${SM_REV} --repo smartmontools/smartmontools-builds \
+            --yes --cleanup-tag || true
+      - name: gh create release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh release create ${SOURCE_DATE_EPOCH}-r${SM_REV} \
+            artifacts/* linux_static_x86_64/* darwin/* freebsd13/* freebsd14/* \
+            linux_static_i386/* windows/* \
+            --repo smartmontools/smartmontools-builds \
+            --notes "Smartmontools CI build: [${SM_VER}-r${SM_REV}](https://github.com/smartmontools/smartmontools/tree/${SM_REV})" \
+            --prerelease
+      - name: Clean old builds
+        # leave only last 30 builds and delete everything else
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}        
+        run: |
+          gh -R smartmontools/smartmontools-builds release list \
+            --json tagName -q '.[30:][]|.tagName' | \
+            xargs -n1 --no-run-if-empty \
+            gh release delete -R smartmontools/smartmontools-build --yes --cleanup-tag

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,10 @@ SRC_TARGETS += cleandist-win32 dist-win32 distdir-win32 install-win32 installer-
 SRC_TARGETS += clean-vc config-vc distclean-vc maintainer-clean-vc
 endif
 
+if OS_DARWIN
+SRC_TARGETS += install-darwin install-darwin-cleanup
+endif
+
 # Avoid automake warning: '.PHONY was already defined in condition ...'
 phony = $(SRC_TARGETS)
 .PHONY: $(phony)


### PR DESCRIPTION
This pipeline is designed to create builds for every commit in the main branch or pull requests (PRs). Only builds from the main branch are published; builds from PRs are used to check that the code is still buildable. Currently supported targets are:
  - linux-static-x86_64
  - linux-static-i386
  - darwin
  - freebsd
  - windows