### PR TITLE
Download signpath back to action and store it as an artifact

### DIFF
--- a/.github/workflows/signpath.yml
+++ b/.github/workflows/signpath.yml
@@ -50,13 +50,9 @@ jobs:
             signing-policy-slug: release-signing
             github-artifact-id: '${{ steps.artifact-upload-step.outputs.artifact-id }}'
             output-artifact-directory: 'signed-artifacts'
-        - name: debug
-          run: cd signed-artifacts && ls -lR
-        - name: unpack signed artifact to avoid zip-inside-zip
-          run: cd signed-artifacts && unzip *.zip && rm *.zip
         - name: upload signed artifact
           uses: actions/upload-artifact@v4
           with:
             name: smartmontools-signed
-            path: signed-artifacts/*
+            path: signed-artifacts/*.exe
             retention-days: 30

--- a/.github/workflows/signpath.yml
+++ b/.github/workflows/signpath.yml
@@ -38,7 +38,7 @@ jobs:
           with:
             name: windows
             path: build/src/smartmontools-win32-setup-*.exe
-            retention-days: 1
+            retention-days: 30
         - name: Submit binary to signpath.io to sign
           # Signing requests must be submitted from upstream repository
           if: ${{ github.repository == 'smartmontools/smartmontools' }}
@@ -49,3 +49,12 @@ jobs:
             project-slug: smartmontools
             signing-policy-slug: release-signing
             github-artifact-id: '${{ steps.artifact-upload-step.outputs.artifact-id }}'
+            output-artifact-directory: 'signed-artifacts'
+        - name: unpack signed artifact to avoid zip-inside-zip
+          run: cd signed-artifacts && unzip *.zip && rm *.zip
+        - name: upload signed artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: smartmontools-signed
+            path: signed-artifacts/*
+            retention-days: 30

--- a/.github/workflows/signpath.yml
+++ b/.github/workflows/signpath.yml
@@ -50,6 +50,8 @@ jobs:
             signing-policy-slug: release-signing
             github-artifact-id: '${{ steps.artifact-upload-step.outputs.artifact-id }}'
             output-artifact-directory: 'signed-artifacts'
+        - name: debug
+          run: cd signed-artifacts && ls -lR
         - name: unpack signed artifact to avoid zip-inside-zip
           run: cd signed-artifacts && unzip *.zip && rm *.zip
         - name: upload signed artifact

--- a/.github/workflows/signpath.yml
+++ b/.github/workflows/signpath.yml
@@ -36,7 +36,7 @@ jobs:
           id: artifact-upload-step
           uses: actions/upload-artifact@v4
           with:
-            name: windows
+            name: smartmontools-windows
             path: build/src/smartmontools-win32-setup-*.exe
             retention-days: 30
         - name: Submit binary to signpath.io to sign
@@ -50,9 +50,9 @@ jobs:
             signing-policy-slug: release-signing
             github-artifact-id: '${{ steps.artifact-upload-step.outputs.artifact-id }}'
             output-artifact-directory: 'signed-artifacts'
-        - name: upload signed artifact
+        - name: Upload signed artifact
           uses: actions/upload-artifact@v4
           with:
-            name: smartmontools-signed
+            name: smartmontools-windows-signed
             path: signed-artifacts/*.exe
             retention-days: 30


### PR DESCRIPTION
This would allow downloading a signed release w/o having access to the signpath.io