### PR TITLE
drivedb.h: Add Netac WH51 USB-to-PCIe/SATA adaptor (0x0dd8:0x9210)

### DIFF
--- a/src/drivedb.h
+++ b/src/drivedb.h
@@ -6162,7 +6162,7 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   { "USB: ; Realtek RTL9210", // USB->PCIe (NVMe)
-    "0x0bda:0x9210",
+    "0x(0bda|0dd8):0x9210", // 0x0bda: Realtek, 0x0dd8: Netac WH51
     "", // 0x2100
     "",
     "-d sntrealtek"


### PR DESCRIPTION
Noticed that despite the Netac WH51 [using a RTL9210B chipset](https://www.netac.com/product/WH51-132.html), it is listed as having vendor ID `0xdd8` (referring to Netac), with `lsusb` output
```
Bus 008 Device 003: ID 0dd8:9210 Netac Technology Co., Ltd WH51
```
As a result, without the patch, `smartctl -i /dev/sda` outputs
```
/dev/sda: Unknown USB bridge [0x0dd8:0x9210 (0x2001)]
Please specify device type with the -d option.
```

With the patch (and a Crucial 1000GB P2 SSD plugged in),  `smartctl -i /dev/sda` outputs
```
=== START OF INFORMATION SECTION ===
Model Number:                       CT1000P2SSD8
Serial Number:                      2204E6010581
Firmware Version:                   P2CR033
PCI Vendor/Subsystem ID:            0xc0a9
IEEE OUI Identifier:                0x6479a7
Total NVM Capacity:                 1,000,204,886,016 [1.00 TB]
Unallocated NVM Capacity:           0
Controller ID:                      1
NVMe Version:                       1.3
Number of Namespaces:               1
Namespace 1 Size/Capacity:          1,000,204,886,016 [1.00 TB]
Namespace 1 Formatted LBA Size:     512
Namespace 1 IEEE EUI-64:            6479a7 5c600000ac
Local Time is:                      Thu Jul 24 15:49:04 2025 HKT
```
as expected.