### PR TITLE
Add attribute bits to Seagate ST1000LM048 and ST1000LM049

### DIFF
--- a/src/drivedb.h
+++ b/src/drivedb.h
@@ -3067,7 +3067,7 @@ const drive_settings builtin_knowndrives[] = {
     "", "", ""
   },
   { "Seagate Barracuda Pro Compute", // tested with ST1000LM049-2GH172/SDM1
-    "ST(1000LM049|500LM034)-.*",
+    "ST500LM034-.*",
     "", "", ""
   },
   { "Seagate Samsung SpinPoint M9T", // tested with ST2000LM003 HN-M201RAD/2BC10003
@@ -4613,10 +4613,13 @@ const drive_settings builtin_knowndrives[] = {
   },
   // ST5000LM000, ST4000LM024, ST3000LM024, ST2000LM015, ST1000LM048, ST500LM030
   { "Seagate Barracuda 2.5 5400", // ST2000LM015-2E8174/SDM1, ST4000LM024-2AN17V/0001
-    "ST(5000LM000|[34]000LM024|2000LM015|1000LM048|500LM030)-.*",
+    "ST(5000LM000|[34]000LM024|2000LM015|1000LM04[89]|500LM030)-.*",
     "",
     "",
+    "-v 1,raw24/raw32 "
+    "-v 7,raw24/raw32 "
     "-v 183,raw48,SATA_Downshift_Count "
+    "-v 188,raw16 "
   },
   { "Seagate Barracuda ES.2", // fixed firmware
     "ST3(25031|50032|75033|100034)0NS",


### PR DESCRIPTION
The ST1000LM048, ST1000LM049, and Seagate drives in general, use different bit layouts for SMART attributes 1, 7, and 188.

This issue has been raised in several places, including [smartmontools issue #220](https://github.com/smartmontools/smartmontools/issues/220), and appears intermittently across the web.

I was uncertain whether to use `-v 1,raw24/raw32`, which yields a value like "0/61603329", or simply `-v 1,raw48:54`, which returns "0". Since these values may be imported or exported by other tools expecting a single integer, I tested both options with the Debian package `prometheus-node-exporter-collectors`, and both formats worked.

However, I'm still unsure how other tools might interpret these values. For this reason, I believe `-v 1,raw48:54` is the safer choice.

Also, this adds the ST1000LM049, which is basically identical as the ST1000LM048. Different manufacturing dates, different label, but with same firmware number as some ST1000LM048.







