### PR TITLE
drivedb: Add WD Re+ 5/6TB

### DIFF
--- a/src/drivedb.h
+++ b/src/drivedb.h
@@ -5402,6 +5402,11 @@ const drive_settings builtin_knowndrives[] = {
     "", "", ""
   //"-v 22,raw48,Helium_Level" // WD121KRYZ, WD141KRYZ
   },
+  { "Western Digital Re+", // tested with WDC WD6005FRPZ-01S9PB0
+      // WDC WD5005FRPZ, WDC WD6005FRPZ-01S9PB0
+    "WDC WD[56]005FRPZ-.*",
+    "", "", ""
+  },
   { "Western Digital Blue Mobile", // tested with WDC WD5000LPVX-08V0TT2/03.01A03,
       // WDC WD10JPVX-75JC3T0/0301A03,  WDC WD10JPVX-22JC3T0/01.01A01,
       // WDC WD20NPVZ-00WFZT0/01.01A01


### PR DESCRIPTION
Small update for these SATA drives, there appear to only be two models. Attached is the smartctl report.

[smartctl-WDC-WD6005FRPZ.txt](https://github.com/user-attachments/files/22047206/smartctl-WDC-WD6005FRPZ.txt)

Here is a diff of smartctl output before and after this addition:
```
--- /dev/fd/63	2025-08-29 13:31:02.255398046 +0000
+++ /dev/fd/62	2025-08-29 13:31:02.255398046 +0000
@@ -2,6 +2,7 @@
 Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

 === START OF INFORMATION SECTION ===
+Model Family:     Western Digital Re+
 Device Model:     WDC WD6005FRPZ-01S9PB0
 Serial Number:    WD-WX21D25R51UH
 LU WWN Device Id: 5 0014ee 05955f1db
@@ -10,7 +11,7 @@
 Sector Sizes:     512 bytes logical, 4096 bytes physical
 Rotation Rate:    5700 rpm
 Form Factor:      3.5 inches
-Device is:        Not in smartctl database [for details use: -P showall]
+Device is:        In smartctl database [for details use: -P show]
 ATA Version is:   ACS-3 T13/2161-D revision 3b
 SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
```