### PR TITLE
drivedb.h: Seagate Exos 16TB X20 and X22 re-certified

### DIFF
--- a/src/drivedb.h
+++ b/src/drivedb.h
@@ -4806,8 +4806,8 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Seagate Exos X20/X22", // tested with ST20000NM007D-3DJ103/SN01, .../SN03,
       // ST22000NM001E-3HM103/SN03, OOS20000G/OOS1
-    "ST(18|20)000NM00[0347]D-.*|" // X20
-    "ST2[02]000NM001E-.*|" // X22
+    "ST(16|18|20)000NM00[0347]D-.*|" // X20
+    "ST(16|2[02])000NM00[01]E-.*|" // X22
     "OOS20000G", // 20TB refurbished and rebranded
     "", "",
     "-v 1,raw24/raw32 -v 7,raw24/raw32 "


### PR DESCRIPTION
X20 and X22 models that have re-certified as 16 TB drives:

- X20: ST16000NM000D
- X22: ST16000NM000E

[smartctl-seagate-exos-x20-recertified-before.txt](https://github.com/user-attachments/files/22326194/smartctl-seagate-exos-x20-recertified-before.txt)

[smartctl-seagate-exos-x20-recertified-after.txt](https://github.com/user-attachments/files/22326193/smartctl-seagate-exos-x20-recertified-after.txt)

[smartctl-seagate-exos-x22-recertified-before.txt](https://github.com/user-attachments/files/22326196/smartctl-seagate-exos-x22-recertified-before.txt)

[smartctl-seagate-exos-x22-recertified-after.txt](https://github.com/user-attachments/files/22326195/smartctl-seagate-exos-x22-recertified-after.txt)
