### PR TITLE
Expose SCSI self-test progress in JSON output

### DIFF
--- a/src/scsiprint.cpp
+++ b/src/scsiprint.cpp
@@ -1104,7 +1104,7 @@ scsiPrintSelfTest(scsi_device * device)
                         sense_info.progress != -1)) {
         int test_progress = (sense_info.progress * 100) / 65535;
 
-        pout("%s execution status:\t\t%d%% of test remaining\n", hname,
+        jout("%s execution status:\t\t%d%% of test remaining\n", hname,
              100 - test_progress);
         jglb["scsi_self_test_status"]["in_progress"] = true;
         jglb["scsi_self_test_status"]["completion_percent"] = test_progress;


### PR DESCRIPTION
Add current self-test status and progress report of SCSI devices to the JSON output.

Resolves #407.

Attached are the sample outputs of `smartctl --json=o ...` from the main branch and with this PR.
JSON from main: [smart-scsi-without-patch.json](https://github.com/user-attachments/files/22619747/smart-scsi-without-patch.json)
JSON from this branch: [smart-scsi-with-patch.json](https://github.com/user-attachments/files/22619748/smart-scsi-with-patch.json)
