### PR TITLE
Add Framework 250/1000G SSD Expansion Cards (0x32ac:0x0005)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -6931,6 +6931,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // Framework Computer Inc
+  { "USB: Framework 250/1000 GB Expansion Card; Phison PS2251",
+    "0x32ac:0x0005",
+    "",
+    "",
+    "-d sntasmedia"
+  },
   // Power Quotient International
   { "USB: PQI bridge; ",
     "0x3538:0x0064",


### PR DESCRIPTION
Before

```
> sudo smartctl -i /dev/sdc
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-6.17.1] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sdc: Unknown USB bridge [0x32ac:0x0005 (0x110)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
```

After

```
> sudo smartctl -i /dev/sdc
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-6.17.1] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       250GB Expansion Card
Serial Number:                      071C3B9D873E2A22
Firmware Version:                   UHFM00.6
PCI Vendor/Subsystem ID:            0x0000
IEEE OUI Identifier:                0x000000
Controller ID:                      0
NVMe Version:                       <1.2
Number of Namespaces:               0
Local Time is:                      Tue Oct 14 17:39:58 2025 CST
```