### PR TITLE
Add JMicron SY-ENC50104 to drivedb (0x152d:0xa576)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -6560,8 +6560,9 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   { "USB: ; JMicron JMS576", // USB3.1->SATA
-    "0x152d:0x[01]576",
+    "0x152d:0x[01a]576",
     "", // 0x0204, ICY BOX IB-223U3a-B
+    // 0x0223 JMicron USA Technology Corp. SY-ENC50104 USB Device
     "",
     "-d sat"
   },


### PR DESCRIPTION
Inspired by #289, I tried this change to `/var/lib/smartmontools/drivedb/drivedb.h`, and it turned this:
```
# smartctl -a /dev/sdd
smartctl 7.4 2023-08-01 r5530 [aarch64-linux-6.16.9+deb14-arm64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sdd: Unknown USB bridge [0x152d:0xa576 (0x5102)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
```
into
```
piepsel:~# smartctl -a /dev/sdd
smartctl 7.4 2023-08-01 r5530 [aarch64-linux-6.16.9+deb14-arm64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sdd: Unknown USB bridge [0x152d:0xa576 (0x5102)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary

piepsel:~# smartctl -a /dev/sdd
smartctl 7.4 2023-08-01 r5530 [aarch64-linux-6.16.9+deb14-arm64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Western Digital Blue (CMR)
Device Model:     WDC WD30(REDACTED)
Serial Number:    (REDACTED)
LU WWN Device Id: 5 0014ee (REDACTED)
```

I encountered this in a device being sold [in the US for example by Newegg](https://www.newegg.com/syba-sy-enc50104-enclosure-3-5/p/N82E16817801144?Item=N82E16817801144), it's a four-drive USB enclosure. I have it attached via USB, it also has eSATA, which I'm unable to try out.