### PR TITLE
feat: add topmore supports (0x152d:0x0901)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -6547,6 +6547,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "" // unsupported
   },
+  { "USB: ; JMicron JMS578", // USB->SATA
+    "0x152d:0x0901",
+    "", // 0x0215: TOPMORE
+    "",
+    "-d sat"
+  },
   { "USB: ; JMicron",
     "0x152d:0x1337",
     "", // 0x0508, Digitus DA-71106


### PR DESCRIPTION
```console
$ sudo smartctl /dev/sda
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-6.16.12-hardened1-1-hardened] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sda: Unknown USB bridge [0x152d:0x0901 (0x215)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
```

with `-d sat` parameters

```console
$ sudo smartctl -d sat /dev/sda
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-6.16.12-hardened1-1-hardened] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

ATA device successfully opened

Use 'smartctl -a' (or '-x') to print SMART (and more) information
```

## Attachments

- `lsusb -d 0x152d:0x0901 -v` run results, [lsusb.txt](https://github.com/user-attachments/files/23445592/lsusb.txt)
- `smartctl -x -a -d sat` run results, [sda.txt](https://github.com/user-attachments/files/23445700/sda.txt)
- <https://item.taobao.com/item.htm?id=791424556523>