### PR TITLE
drivedb.h: Maxio based SSDs

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -614,6 +614,7 @@ const drive_settings builtin_knowndrives[] = {
     "Patriot Burst Elite (120|240|480|960|1920)GB|"  // Patriot Burst Elite 120GB/SN08979, 1920GB/SN09405
     "SPCC Solid State Disk|"                         // Silicon Power A55, tested with SPCC Solid State Disk/H190117H (512GB)
         // SPCC Solid State Disk/SN08921 (128GB)
+        // also available with Phison controllers
     "SSDPR-CX400-(128|256|512|01T|02T)-G2|"          // GOODRAM CX400 G2, tested with SSDPR-CX400-128-G2/SN07373
         // also available with Phison controllers
     "Verbatim Vi560 SATA III M.2 SSD",               // Verbatim Vi560 SATA III M.2 SSD/H190505 (256GB)


### PR DESCRIPTION
Fix attributes 5, 169, 173, 192, 241, 242, 245 for Lexar 128GB SSD. Rename it to Maxio based SSD and filter by firmware version. Fixes trac tickets 1480, 1531, 1689, 1690, 1703.

Also add Maxio based SSDs (newer firmware), different attribute 167. Fixes #185, fixes #196, trac tickets 1709, 1774.