### PR TITLE
drivedb.h: Seagate BarraCuda (HAMR series) (ST26000DM000)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -4703,20 +4703,6 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
-  { "Seagate IronWolf Pro (HAMR)", // untested
-      // HAMR based IronWolf Pro, Mozaic 3+ platform, similar to Exos M series
-      // ST24000NT031
-      // ST28000NT000
-      // ST30000NT011-3V2103/EN02
-      // ST32000NT000
-    "ST(32000NT000|30000NT011|28000NT000|24000NT031)-3V.103",
-    "", "",
-    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
-    "-v 18,raw48,Head_Health "
-    "-v 188,raw16 "
-    "-v 200,raw48,Pressure_Limit "
-    "-v 240,msec24hour32"
-  },
   { "Seagate Constellation (SATA)", // tested with ST9500530NS/SN03
     "ST9(160511|500530)NS",
     "", "", ""


### PR DESCRIPTION
Fix #429.

I own ST26000DM000-3Y8103, other models came from photos uploaded to Internet and/or spec sheets from Seagate.