### PR TITLE
drivedb.h: Seagate IronWolf Pro (HAMR)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -5167,7 +5167,6 @@ const drive_settings builtin_knowndrives[] = {
     "ST(24000NT031|28000NT000|30000NT011|32000NT000)-...103",
     "", "",
     "-v 1,raw24/raw32 -v 7,raw24/raw32 "
-    "-v 18,raw48,Head_Health "
     "-v 188,raw16 "
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"


### PR DESCRIPTION
On hold until someone provides a sample output.

So far only 30TB is being sold, 24/28/32TB are not seen yet.

P/N and F/W for 24/28/32TB are retrieved from external reference: https://www.asustor.com/service/hd?series_id=24&id=hd&brand_id=3&type_id=2&size=&class=NAS

Brand | Type | Model | Size | Class | HDD/SSD Series | Firmware version
-- | -- | -- | -- | -- | -- | --
Seagate | 3.5'' SATA HDD | ST32000NT000 - 3TP103-500 | 32 TB | NAS | IronWolf Pro | EN02
Seagate | 3.5'' SATA HDD | ST30000NT011 - 3V2103-500 | 30 TB | NAS | IronWolf Pro | EN02
Seagate | 3.5'' SATA HDD | ST28000NT000 - 4AB103-500 | 28 TB | NAS | IronWolf Pro | EN02
Seagate | 3.5'' SATA HDD | ST24000NT031 - 3UH103-500 | 24 TB | NAS | IronWolf Pro | EN02
