### PR TITLE
drivedb.h: Seagate Video 2.5 (ST320VT000)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -4981,6 +4981,11 @@ const drive_settings builtin_knowndrives[] = {
     "ST9(40|80)210AS?",
     "", "", ""
   },
+  { "Seagate Video 2.5", // tested with ST320VT000-1BS14C/0001SDC1
+    "ST(320|500)VT000-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 -v 188,raw16 "
+  },
   { "Seagate ST1.2 CompactFlash", // tested with ST68022CF/3.01
     "ST6[468]022CF",
     "", "", ""


### PR DESCRIPTION
Fixes trac ticket [1660](https://www.smartmontools.org/ticket/1660)

From [datasheet](https://www.seagate.com/content/dam/seagate/migrated-assets/www-content/product-content/seagate-video-hdd-fam/video-2-5-hdd/_shared/docs/ds-1772-4-1707us-video-2.5-hdd.pdf).