### PR TITLE
drivedb.h: Toshiba 3.5" DT02 series Desktop HDD (DT02ACA200)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -4210,6 +4210,10 @@ const drive_settings builtin_knowndrives[] = {
     "TOSHIBA DT01ACA(025|032|050|075|100|150|200|300)",
     "", "", ""
   },
+  { "Toshiba 3.5\" DT02 series Desktop HDD", // tested with TOSHIBA DT02ACA200/KS002A
+    "TOSHIBA DT02A(BA[246]|CA2)00",
+    "", "", ""
+  },
   { "Toshiba N300/MN NAS HDD", // tested with TOSHIBA HDWQ140/FJ1M, TOSHIBA HDWN160/FS1M,
       // TOSHIBA HDWN180/GX2M, TOSHIBA HDWG440/0601 (4TB), TOSHIBA HDWG480/0601 (8TB),
       // TOSHIBA HDWG11A/0603 (10TB), TOSHIBA HDWG21C/0601 (12TB), TOSHIBA HDWG21E/0601 (14TB),


### PR DESCRIPTION
Fixes #245

Using product overviews from [2020](https://storage.toshiba.com/docs/internal-specialty-documents/dt02_product_overview_rev4s.pdf) and [2022](https://toshiba.semicon-storage.com/content/dam/toshiba-ss-v3/master/en/storage/product/internal-specialty/DT02_product_overview_7200rpm.pdf).