### PR TITLE
drivedb.h: Seagate FireCuda 3.5 (ST4000DX005-3GH101)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -3119,13 +3119,20 @@ const drive_settings builtin_knowndrives[] = {
   },
   // Flash accelerated, no SMART info in the specs
   // ST1000LX015-1U7172/SDM1
-  { "Seagate FireCuda 2.5",
+  { "Seagate FireCuda 2.5 SSHD",
     "ST(500|1000|2000)LX0(01|15|25)-.*",
     "", "", "-v 240,msec24hour32 "
   },
-  { "Seagate FireCuda 3.5", // ST2000DX002-2DV164/CC41
+  { "Seagate FireCuda 3.5 SSHD", // ST2000DX002-2DV164/CC41
     "ST[12]000DX002-.*",
     "", "", "-v 240,msec24hour32 "
+  },
+  { "Seagate FireCuda 3.5", // tested with ST4000DX005-3GH101/FC01
+    "ST[48]000DX00[15]-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 -v 188,raw16 "
+    "-v 18,raw48,Head_Health "
+    "-v 240,msec24hour32"
   },
   { "Seagate Samsung SpinPoint M9TU (USB)", // tested with ST1500LM008 HN-M151AAD/2BC10001
       // (0x04e8:0x61b5), ST2000LM005 HN-M201AAD2BC10001 (0x04e8:0x61b4)


### PR DESCRIPTION
Append SSHD to the existing FireCuda 2.5/3.5 model families. Assign the 4/8TB HDDs to Seagate FireCuda 3.5.

Fixes trac ticket [1754](https://www.smartmontools.org/ticket/1754).