### PR TITLE
drivedb.h: update Phison driven SSDs (Foxline X5 SE series)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -905,6 +905,7 @@ const drive_settings builtin_knowndrives[] = {
     "Corsair Force LE(200)? SSD|" // tested with Corsair Force LE SSD/SAFC11.0,
       // Corsair Force LE200 SSD/SBFM10, .../SBFM60.9
     "DGSR2(128|256|512)GP13T|"  // tested with DGSR2512GP13T/SBFM61.5
+    "FOXLINE FLSSD(120|128|240|256|480|512|960|1024)X5SE|" // tested with FoxLine FLSSD240X5SE/SBFM61.5
     "GIGABYTE GP-GSTFS31((120|240|256|480)G|100T)NTD|" // tested with GIGABYTE GP-GSTFS31120GNTD/SBFM61.3
     "GOODRAM IRIDIUM PRO|" // tested with GOODRAM IRIDIUM PRO/SAFM01.5
     "IRP?-SSDPR-S25[AC]-(120|240|256|480|512|960|0[12]T)|" // Goodram IRIDM (PRO), tested with


### PR DESCRIPTION
Vendor site [https://fox-line.ru/catalog/ssd-drives/flssd240x5se.html](https://fox-line.ru/catalog/ssd-drives/flssd240x5se.html)
X5SE series drive (120Gb, ... 1024Gb) spec file pointed to "PS3111 Sata Controller", so update Phison driven OEM ssd's section in drivedb.h file.
Tested with FOXLINE FLSSD240X5SE FW SBFM61.5

before patch:
```
smartctl pre-8.0-274 2025-11-17 [x86_64-linux-6.1.141-1-generic] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     FOXLINE FLSSD240X5SE
Serial Number:    2021090621609
Firmware Version: SBFM61.5
User Capacity:    240 057 409 536 bytes [240 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available
Device is:        Not in smartctl database 7.5/5988
ATA Version is:   ACS-4 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Thu Nov 20 12:15:27 2025 MSK
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000b   100   100   050    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0012   100   100   000    Old_age   Always       -       6798
 12 Power_Cycle_Count       0x0012   100   100   000    Old_age   Always       -       760
168 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       0
170 Unknown_Attribute       0x0003   100   100   000    Pre-fail  Always       -       219
173 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       3276881
192 Power-Off_Retract_Count 0x0012   100   100   000    Old_age   Always       -       95
194 Temperature_Celsius     0x0023   067   067   000    Pre-fail  Always       -       33 (Min/Max 33/33)
218 Unknown_Attribute       0x000b   100   100   050    Pre-fail  Always       -       10
231 Unknown_SSD_Attribute   0x0013   100   100   000    Pre-fail  Always       -       98
241 Total_LBAs_Written      0x0012   100   100   000    Old_age   Always       -       6655
```

after patch:
```
smartctl pre-8.0-274 2025-11-17 [x86_64-linux-6.1.141-1-generic] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Phison Driven OEM SSDs
Device Model:     FOXLINE FLSSD240X5SE
Serial Number:    2021090621609
Firmware Version: SBFM61.5
User Capacity:    240 057 409 536 bytes [240 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available
Device is:        In smartctl database 7.5/5988
ATA Version is:   ACS-4 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Thu Nov 20 12:15:38 2025 MSK
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000b   100   100   050    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0012   100   100   000    Old_age   Always       -       6798
 12 Power_Cycle_Count       0x0012   100   100   000    Old_age   Always       -       760
168 SATA_Phy_Error_Count    0x0012   100   100   000    Old_age   Always       -       0
170 Bad_Blk_Ct_Lat/Erl      0x0003   100   100   000    Pre-fail  Always       -       0/219
173 MaxAvgErase_Ct          0x0012   100   100   000    Old_age   Always       -       81 (Average 50)
192 Unsafe_Shutdown_Count   0x0012   100   100   000    Old_age   Always       -       95
194 Temperature_Celsius     0x0023   067   067   000    Pre-fail  Always       -       33 (Min/Max 33/33)
218 CRC_Error_Count         0x000b   100   100   050    Pre-fail  Always       -       10
231 SSD_Life_Left           0x0013   100   100   000    Pre-fail  Always       -       98
241 Lifetime_Writes_GiB     0x0012   100   100   000    Old_age   Always       -       6655
```
