### PR TITLE
drivedb.h: Move Seagate Factory Recertified Exos to its own section

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -4962,7 +4962,7 @@ const drive_settings builtin_knowndrives[] = {
       // ST24000NM000C-3WD103/SN02
       // ST26000NM000C-3WE103/SN02
       // ST28000NM000C-3WM103/SN04
-    "ST(16|20|22|24|26|28)NM00[02]-3..103",
+    "ST(16|20|22|24|26|28)000NM00[02]C-3..103",
     "", "",
     "-v 1,raw24/raw32 -v 7,raw24/raw32 "
     "-v 18,raw48,Head_Health "


### PR DESCRIPTION
Seagate Exos Recertified is a separate product line from Seagate

Product page: https://www.seagate.com/support/internal-hard-drives/enterprise-hard-drives/exos/

Datasheet: https://www.seagate.com/content/dam/seagate/assets/support/internal-hard-drives/enterprise-hard-drives/exos/_shared/files/exos-recertified-DS20-2-2503US-en_US.pdf

Contains the following drives
```
ST16000NM002C-3YG103/SN04
ST20000NM002C-3X6103/SN04
ST22000NM000C-3WC103/SN02
ST24000NM000C-3WD103/SN02
ST26000NM000C-3WE103/SN02
ST28000NM000C-3WM103/SN04
```

They are HAMR based products just like the Barracuda HAMR line. There's no retail counterpart of those drives, so they are recertified drives to begin with (presumerably recertified from returns from private sales, or binned retail Exos M, we don't know). They are not X20/X22/X24 series, which are non-HAMR drives.

The full text output was provided in #424. I don't own such drives.