### PR TITLE
drivedb.h: USB: Transcend TS-CM10G (0x2174:0x7010)

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -7144,6 +7144,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  { "USB: Transcend TS-CM10G; ",
+    "0x2174:0x7010",
+    "", // 0x2227
+    "",
+    "-d sntrealtek"
+  },
   // 0x235c (?)
   { "USB: ; ",
     "0x235c:0xa006", // Terramaster D4-320 (see also 0x5432:0x235c)


### PR DESCRIPTION
Transcend TS-CM10G NVMe box not being recognized by latest smartctl on main branch:
```
$ sudo ./src/smartctl -q noserial -x -a /dev/sda

smartctl pre-8.0-314 2025-12-03 [x86_64-linux-6.17.0-8-generic] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sda: Unknown USB bridge [0x2174:0x7010 (0x2227)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
```

It is recognizable with `-d sntrealtek`:
```
$ sudo ./src/smartctl -q noserial -d sntrealtek -x -a /dev/sda
smartctl pre-8.0-314 2025-12-03 [x86_64-linux-6.17.0-8-generic] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       WD Red SN700 2000GB
Firmware Version:                   112000WD
PCI Vendor/Subsystem ID:            0x15b7
IEEE OUI Identifier:                0x001b44
Total NVM Capacity:                 2,000,398,934,016 [2.00 TB]
Unallocated NVM Capacity:           0
Controller ID:                      8215
NVMe Version:                       1.3
Number of Namespaces:               1
Namespace 1 Size/Capacity:          2,000,398,934,016 [2.00 TB]
Namespace 1 Formatted LBA Size:     512
Local Time is:                      Tue Dec 16 16:44:47 2025 CST
Firmware Updates (0x14):            2 Slots, no Reset required
Optional Admin Commands (0x0017):   Security Format Frmw_DL Self_Test
Optional NVM Commands (0x005f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat Timestmp
Log Page Attributes (0x0e):         Cmd_Eff_Lg Ext_Get_Lg Telmtry_Lg
Maximum Data Transfer Size:         128 Pages
Warning  Comp. Temp. Threshold:     84 Celsius
Critical Comp. Temp. Threshold:     88 Celsius
Namespace 1 Features (0x02):        NA_Fields

Supported Power States
St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
 0 +     6.00W       -        -    0  0  0  0        0       0
 1 +     3.50W       -        -    1  1  1  1        0       0
 2 +     3.00W       -        -    2  2  2  2        0       0
 3 -   0.1000W       -        -    3  3  3  3     4000   12000
 4 -   0.0035W       -        -    4  4  4  4     4000   45000

Supported LBA Sizes (NSID 0x1)
Id Fmt  Data  Metadt  Rel_Perf
 0 +     512       0         2
 1 -    4096       0         1

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02, NSID 0xffffffff)
Critical Warning:                   0x00
Temperature:                        48 Celsius
Available Spare:                    100%
Available Spare Threshold:          10%
Percentage Used:                    0%
Data Units Read:                    3,907,032 [2.00 TB]
Data Units Written:                 0
Host Read Commands:                 122,102,278
Host Write Commands:                0
Controller Busy Time:               29
Power Cycles:                       4
Power On Hours:                     1
Unsafe Shutdowns:                   0
Media and Data Integrity Errors:    0
Error Information Log Entries:      0
Warning  Comp. Temperature Time:    0
Critical Comp. Temperature Time:    0

Warning: NVMe Get Log truncated to 0x200 bytes, 0x200 bytes zero filled
Error Information (NVMe Log 0x01, 16 of 256 entries)
No Errors Logged

Warning: NVMe Get Log truncated to 0x200 bytes, 0x034 bytes zero filled
Self-test Log (NVMe Log 0x06, NSID 0xffffffff)
Self-test status: No self-test in progress
No Self-tests Logged
```

Firmware was upgraded via official Windows-only tool,  
so fw version does not match the out-of-the-box status.

Added the entry matching its device id to `drivedb.h`.