### PR TITLE
drivedb.h: Silicon Motion based OEM SSDs: Patriot Burst Elite

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -2560,6 +2560,7 @@ const drive_settings builtin_knowndrives[] = {
     "ORICO|" // ORICO S500PRO, tested with ORICO/W0201A0 (2TB)
     "ORTIAL SSD|" // tested with ORTIAL SSD/U0202A0 (128GB)
     "P4-(120|240|480|960)|" // Kingspec P4, tested with P4-240/VE0R6327
+    "Patriot Burst Elite (120|240|480|960|1920)GB|"  // tested with Patriot Burst Elite 480GB/V1102A0, 960GB/V0414A0
     "RX7 (240|256|512)G|" // tested with RX7 240G/T0910A0
     "SATA3 ((12[08]|240|256|480)G|[12]T)B SSD|" // TCSUNBOW X3, tested with SATA3 240GB SSD/S0618A0,
       // SATA3 1TB SSD/S1230A0,
@@ -2574,7 +2575,7 @@ const drive_settings builtin_knowndrives[] = {
     "Vi550 S3", // another variant (ticket #1899), tested with Vi550 S3/HP3418C5
     "HP(3418C5|S2227I)|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R(0529A|0817B0)|"
     "S(0222|0424|0509|0618|1211|1230)A0|S112[78]B0|T0(311|519|910)A0|"
-    "U(0202|0309|0401|0506|1124|1209)A0|V0((609|823)A|(303|718)B)0|V1027A0|VE0R6327|"
+    "U(0202|0309|0401|0506|1124|1209)A0|V0((414|609|823)A|(303|718)B)0|V1(027|102)A0|VE0R6327|"
     "W(0201|0413|0714|0825)A0",
     "",
     "-v 148,raw48,Total_SLC_Erase_Ct "


### PR DESCRIPTION
Fixes #467.