### PR TITLE
farmprint.cpp: correct string format for ID Word

### DIFF
--- a/src/farmprint.cpp
+++ b/src/farmprint.cpp
@@ -212,8 +212,8 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   jout("\t\tDevice Form Factor: %s\n", formFactor);
   jout("\t\tRotation Rate: %" PRIu64 " rpm\n", farmLog.driveInformation.rotationRate);
   jout("\t\tFirmware Rev: %s\n", firmwareRev);
-  jout("\t\tATA Security State (ID Word 128): 0x016%" PRIx64 "\n", farmLog.driveInformation.security);
-  jout("\t\tATA Features Supported (ID Word 78): 0x016%" PRIx64 "\n", farmLog.driveInformation.featuresSupported);
+  jout("\t\tATA Security State (ID Word 128): 0x%016" PRIx64 "\n", farmLog.driveInformation.security);
+  jout("\t\tATA Features Supported (ID Word 78): 0x%016" PRIx64 "\n", farmLog.driveInformation.featuresSupported);
   jout("\t\tATA Features Enabled (ID Word 79): 0x%016" PRIx64 "\n", farmLog.driveInformation.featuresEnabled);
   jout("\t\tPower on Hours: %" PRIu64 "\n", farmLog.driveInformation.poh);
   jout("\t\tSpindle Power on Hours: %" PRIu64 "\n", farmLog.driveInformation.spoh);


### PR DESCRIPTION
Original farmprint.cpp has a typo error which mis-format ID word in farm:
```
                ATA Features Supported (ID Word 78): 0x0168cc
```
By looking into `--identify` the ID word 78 is actually 0x8cc:
```
  78      -     0x08cc   Serial ATA features supported
  78     11          1   Rebuild Assist feature set supported
  78      7          1   NCQ Autosense supported
  78      6          1   Software Settings Preservation supported
  78      3          1   Device initiated power management supported
  78      2          1   DMA Setup auto-activation supported
```
After fix it could show correctly:
```
                ATA Features Supported (ID Word 78): 0x00000000000008cc
```