### PR TITLE
drivedb.h: IBM Travelstar 6GN, 40GN: Fix attributes

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -3693,9 +3693,10 @@ const drive_settings builtin_knowndrives[] = {
     "IBM-DTCA-2(324|409)0",
     "", "", ""
   },
-  { "IBM Travelstar 6GN",
+  { "IBM Travelstar 6GN", // tested with IBM-DBCA-204860/BC3OA87F
     "IBM-DBCA-20(324|486|648)0",
-    "", "", ""
+    "", "",
+    "-v 8,raw16 -v 226,raw16"
   },
   { "IBM Travelstar 25GS, 18GT, and 12GN",
     "IBM-DARA-2(25|18|15|12|09|06)000",
@@ -3721,9 +3722,10 @@ const drive_settings builtin_knowndrives[] = {
     "IBM-DKLA-2(216|324|432)0",
     "", "", ""
   },
-  { "IBM/Hitachi Travelstar 60GH and 40GN",
+  { "IBM/Hitachi Travelstar 60GH and 40GN", // tested with IC25N030ATCS04-0/CA3OA71A
     "(IBM-|Hitachi )?IC25(T060ATC[SX]05|N0[4321]0ATC[SX]04)-.",
-    "", "", ""
+    "", "",
+    "-v 191,raw16"
   },
   { "IBM/Hitachi Travelstar 40GNX",
     "(IBM-|Hitachi )?IC25N0[42]0ATC[SX]05-.",


### PR DESCRIPTION
For 6GN, attributes 8 and 226 are in raw16.
For 40GN, attribute 191 is in raw 16.

[smartctl-IBM-DBCA-204860.txt](https://github.com/user-attachments/files/24224043/smartctl-IBM-DBCA-204860.txt) (does not support self-tests so `-t offline` was run instead)
[smartctl-IBM-IC25N030ATCS04-0.txt](https://github.com/user-attachments/files/24224044/smartctl-IBM-IC25N030ATCS04-0.txt)
