### PR TITLE
drivedb.h: Seagate Exos M

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -5113,6 +5113,19 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
+  { "Seagate Exos M", // tested with ST30000NM004K-3RM133/SE02
+      // HAMR based Exos M, Mozaic 3+ platform
+      // ST24000NM001K-3TH133/SE02
+      // ST28000NM003K-3TE133/SE02
+      // ST30000NM004K-3RM133/SE02
+      // ST32000NM004K-3UB133/SE02
+    "ST(24000NM001|28000NM003|30000NM004|32000NM004)K-3..133",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
   // new models: ST8000VN0002, ST6000VN0021, ST4000VN000
   //             ST8000VN0012, ST6000VN0031, ST4000VN003
   // tested with ST8000VN0002-1Z8112/ZA13YGNF


### PR DESCRIPTION
Product page: https://www.seagate.com/products/enterprise-drives/exos/exos-m/

P/N and F/W are retrieved from external reference: https://www.asustor.com/service/hd?series_id=16&id=hd&brand_id=3&type_id=2&size=&class=Enterprise

Brand | Type | Model | Size | Class | HDD/SSD Series | Firmware version
-- | -- | -- | -- | -- | -- | --
Seagate | 3.5'' SATA HDD | ST32000NM004K - 3UB133 | 32 TB | Enterprise | Exos M | SE02
Seagate | 3.5'' SATA HDD | ST30000NM004K - 3RM133 | 30 TB | Enterprise | Exos M | SE02
Seagate | 3.5'' SATA HDD | ST28000NM003K - 3TE133 | 28 TB | Enterprise | Exos M | SE02
Seagate | 3.5'' SATA HDD | ST24000NM001K - 3TH133 | 24 TB | Enterprise | Exos M | SE02

Sample output was provided by plntyk in #435.

Entry 1, 7, 18 behave differently than previous gen of HAMR drives (Barracuda HAMR and Recertified Exos). 18 was removed, however 1 and 7 remain the same until we have an example of non-zero RAW values.

```
  1 Raw_Read_Error_Rate     POSR--   082   064   044    -    0
  7 Seek_Error_Rate         POSR--   079   061   045    -    0

Error Rate (SMART Attribute 1 Raw): 0x0000000008a3d0e8
Error Rate (SMART Attribute 1 Normalized): 82
Error Rate (SMART Attribute 1 Worst): 64
Seek Error Rate (SMART Attr 7 Raw): 0x00000000047a8ea3
Seek Error Rate (SMART Attr 7 Normalized): 79
Seek Error Rate (SMART Attr 7 Worst): 61
```