### PR TITLE
drivedb.h: add ExeGate pn EX276539RUS drive

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -2469,6 +2469,7 @@ const drive_settings builtin_knowndrives[] = {
     "DREVO X1 SSD|" // tested with DREVO X1 SSD/Q0111A
     "Drevo X1 pro (64|128|256)G|" // tested with Drevo X1 pro 64G/Q0303B
     "DEXP SSD C100 (128|256|512)Gb|" // tested with DEXP SSD C100 256Gb/V0218A0
+    "EX27(8215|653[69]|668[35])RUS|" // ExeGate NextPro UV500TS, tested with EX276539RUS/HP3418B2 (240GB)
     "HP SSD S700 ((128|256|512)G|1T)B|" // tested with HP SSD S700 1TB/V0823A0
     "JAJS[56]00M((12[08]|240|256|480|512|960)C|1TB)(-1)?|" // J&A LEVEN JS500/600 (Intenso TOP), tested with
       // JAJS500M120C-1/P0614D, JAJS600M1TB/T0529A0, JAJS600M256C/U0803A0


### PR DESCRIPTION
Please add another Silicon Motion based OEM SSD - ExeGate NextPro UV500TS240/HP3418B2
[before.txt](https://github.com/user-attachments/files/24355105/before.txt)
[after.txt](https://github.com/user-attachments/files/24355107/after.txt)