### PR TITLE
drivedb.h: ZHITAI SC001 SATA SSD

### DIFF
--- a/lib/drivedb.h
+++ b/lib/drivedb.h
@@ -613,21 +613,29 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Maxio based SSDs (variant 1)", // MK8115, MAS0902
     "NT-(128|256|512)|"         // KingSpec NT, tested with NT-512/T180731
-    "P3-(128|256|512|[124]TB)", // KingSpec P3, tested with P3-256/T180910, P3-1TB/T180731
-    "T18[0-9]{4}", "",
+    "P3-(128|256|512|[124]TB)|" // KingSpec P3, tested with P3-256/T180910, P3-1TB/T180731
+    "ZHITAI SC001 (Active ((256|512)GB|1TB) SSD|XT (250|500|1000)GB)",  // tested with
+    // ZHITAI SC001 SATA SSD/ZT016200
+    "T18[0-9]{4}|ZT[0-9A-Z]{6}", "",
+    "-v 5,raw16(raw16),New_Bad_Block_Count "
   //"-v 9,raw24(raw8),Power_On_Hours "
   //"-v 12,raw48,Power_Cycle_Count "
     "-v 167,raw48,SSD_Protect_Mode "
     "-v 168,raw48,SATA_PHY_Error_Count "
     "-v 169,raw16(raw16),Bad_Block_Count "
+    "-v 170,raw48,Max_Bad_Block_Count "
     "-v 171,raw48,Program_Fail_Count "
     "-v 172,raw48,Erase_Fail_Count "
     "-v 173,raw16,Erase_Count "
     "-v 175,raw48,Bad_Cluster_Count "
     "-v 180,raw48,Spare_Blk_Count_Left "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
   //"-v 187,raw48,Reported_Uncorrect "
+    "-v 190,tempminmax,Temperature_Celsius "
     "-v 192,raw48,Unexpect_Power_Loss_Ct "
   //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 196,raw48,Reallocated_Event_Count "
     "-v 206,raw48,Min_Erase_Count "
     "-v 207,raw48,Max_Erase_Count "
     "-v 208,raw48,Avg_Erase_Count "
@@ -635,8 +643,11 @@ const drive_settings builtin_knowndrives[] = {
     "-v 210,raw48,SLC_Max_Erase_Count "
     "-v 211,raw48,SLC_Avg_Erase_Count "
     "-v 231,raw48,SSD_Life_Left "
+    "-v 233,raw48,NAND_Write_Sector_Cnt "
+    "-v 234,raw48,NAND_Read_Sector_Cnt "
   //"-v 241,raw48,Total_LBAs_Written "
   //"-v 242,raw48,Total_LBAs_Read "
+    "-v 243,raw48,NAND_Temperature "
     "-v 245,raw16(raw16),Bit_Error_Count"
   },
   { "Maxio based SSDs (variant 2)", // MAS0902, MAS1102


### PR DESCRIPTION
Support ZHITAI SC001 SATA SSD, here an example for ZHITAI SC001 Active 256GB SSD.

```
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.0-174.el10.x86_64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     ZHITAI SC001 SATA SSD
Device Model:     ZHITAI SC001 Active 256GB SSD
Serial Number:    ZTB1256KA2212009A8
LU WWN Device Id: 5 a428b7 225997472
Firmware Version: ZT016200
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, zeroed
Device is:        In smartctl database 7.3/6028
ATA Version is:   ACS-2 (minor revision not indicated)
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Mon Jan  5 19:03:09 2026 CST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Disabled
ATA Security is:  Disabled, frozen [SEC2]
Wt Cache Reorder: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever
                                        been run.
Total time to complete Offline
data collection:                (   33) seconds.
Offline data collection
capabilities:                    (0x7b) SMART execute Offline immediate.
                                        Auto Offline data collection on/off support.
                                        Suspend Offline collection upon new
                                        command.
                                        Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0003) Saves SMART data before entering
                                        power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        (   2) minutes.
Conveyance self-test routine
recommended polling time:        (   2) minutes.
SCT capabilities:              (0x0031) SCT Status supported.
                                        SCT Feature Control supported.
                                        SCT Data Table supported.

SMART Attributes Data Structure revision number: 20
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  5 New_Bad_Block_Count     PO--C-   100   100   050    -    0
  9 Power-On_Hours_Count    -O--C-   100   100   000    -    14043
 12 Power_Cycle_Count       -O--C-   100   100   000    -    161
170 Max_Bad_Block_Count     PO--CK   100   100   000    -    361
168 SATA_PHY_Error_Count    -O--C-   100   100   000    -    4
169 Bad_Block_Count         PO--C-   100   100   010    -    983088
171 Program_Fail_Count      -O--CK   000   000   000    -    0
172 Erase_Fail_Count        -O--CK   000   000   000    -    0
173 Erase_Count             -O--C-   200   200   000    -    472471306547
175 Bad_Cluster_Count       -O---K   100   100   010    -    0
183 SATA_Interface_Downshift-O--CK   000   000   000    -    0
184 E2E_Error_Detection_Cnt -O--CK   000   000   000    -    0
187 Uncorrectable_Error_Cnt -O--CK   100   000   000    -    0
192 Unexpected_Pwr_Loss_Cnt -O--C-   100   100   000    -    152
190 Temperature             -O---K   033   033   000    -    33 (Min/Max 31/41)
196 Re-allocated_Event_Cnt  -O--C-   100   100   000    -    0
199 CRC_Error_Count         -O--C-   100   100   000    -    0
206 Minimum_Erase_Count     -O--CK   200   200   000    -    110
207 Maximum_Erase_Count     -O--CK   200   200   000    -    380
208 Average_Erase_Count     -O--CK   200   200   000    -    307
209 SLC_Minimum_Erase_Count -O--CK   200   200   000    -    1
210 SLC_Maximum_Erase_Count -O--CK   200   200   000    -    4045
211 SLC_Average_Erase_Count -O--CK   200   200   000    -    2909
231 SSD_Life_Left           PO---K   080   080   005    -    20
233 Write_sector_cnt_to_NAND-O--CK   100   100   000    -    237862115328
234 Read_sector_cnt_to_NAND -O--CK   100   100   000    -    138658480576
241 Total_LBA_written       -O--CK   100   100   000    -    1516344684
242 Total_LBA_Read          -O--CK   100   100   000    -    1268518720
245 Bit_Error_Count         -O--CK   100   100   000    -    463018905
243 NAND_Temperature        -O--CK   050   050   000    -    17
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O     51  Comprehensive SMART error log
0x03       GPL     R/O     64  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x09           SL  R/W      1  Selective self-test log
0x0a       GPL     R/W      2  Device Statistics Notification
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (64 sectors)
Device Error Count: 4
        CR     = Command Register
        FEATR  = Features Register
        COUNT  = Count (was: Sector Count) Register
        LBA_48 = Upper bytes of LBA High/Mid/Low Registers ]  ATA-8
        LH     = LBA High (was: Cylinder High) Register    ]   LBA
        LM     = LBA Mid (was: Cylinder Low) Register      ] Register
        LL     = LBA Low (was: Sector Number) Register     ]
        DV     = Device (was: Device/Head) Register
        DC     = Device Control Register
        ER     = Error register
        ST     = Status register
Powered_Up_Time is measured from power on, and printed as
DDd+hh:mm:SS.sss where DD=days, hh=hours, mm=minutes,
SS=sec, and sss=millisec. It "wraps" after 49.710 days.

Error 4 [3] occurred at disk power-on lifetime: 3953 hours (164 days + 17 hours)
  When the command that caused the error occurred, the device was in an unknown state.

  After command completion occurred, registers were:
  ER -- ST COUNT  LBA_48  LH LM LL DV DC
  -- -- -- == -- == == == -- -- -- -- --
  84 -- 41 00 08 00 00 01 06 02 80 40 00

  Commands leading to the command that caused the error were:
  CR FEATR COUNT  LBA_48  LH LM LL DV DC  Powered_Up_Time  Command/Feature_Name
  -- == -- == -- == == == -- -- -- -- --  ---------------  --------------------
  06 00 01 00 01 00 00 00 00 00 00 00 80     23:14:49.100  DATA SET MANAGEMENT
  b0 00 da 00 00 00 00 00 c2 4f 00 00 80     23:14:27.000  SMART RETURN STATUS
  b0 00 d1 00 01 00 00 00 c2 4f 00 00 80     23:14:27.000  SMART READ ATTRIBUTE THRESHOLDS [OBS-4]
  b0 00 d0 00 01 00 00 00 c2 4f 00 00 80     23:14:27.000  SMART READ DATA
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80     23:14:27.000  IDENTIFY DEVICE

Error 3 [2] occurred at disk power-on lifetime: 3938 hours (164 days + 2 hours)
  When the command that caused the error occurred, the device was in an unknown state.

  After command completion occurred, registers were:
  ER -- ST COUNT  LBA_48  LH LM LL DV DC
  -- -- -- == -- == == == -- -- -- -- --
  84 -- 41 00 08 00 00 01 05 32 08 40 00  Error: ABRT

  Commands leading to the command that caused the error were:
  CR FEATR COUNT  LBA_48  LH LM LL DV DC  Powered_Up_Time  Command/Feature_Name
  -- == -- == -- == == == -- -- -- -- --  ---------------  --------------------
  b0 00 da 00 00 00 00 00 c2 4f 00 00 80     22:07:16.400  SMART RETURN STATUS
  b0 00 d1 00 01 00 00 00 c2 4f 00 00 80     22:07:16.400  SMART READ ATTRIBUTE THRESHOLDS [OBS-4]
  b0 00 d0 00 01 00 00 00 c2 4f 00 00 80     22:07:16.400  SMART READ DATA
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80     22:07:16.400  IDENTIFY DEVICE
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80     22:07:16.400  IDENTIFY DEVICE

Error 2 [1] occurred at disk power-on lifetime: 3543 hours (147 days + 15 hours)
  When the command that caused the error occurred, the device was in an unknown state.

  After command completion occurred, registers were:
  ER -- ST COUNT  LBA_48  LH LM LL DV DC
  -- -- -- == -- == == == -- -- -- -- --
  84 -- 41 00 08 00 00 01 23 ab 68 40 00  Error: ABRT

  Commands leading to the command that caused the error were:
  CR FEATR COUNT  LBA_48  LH LM LL DV DC  Powered_Up_Time  Command/Feature_Name
  -- == -- == -- == == == -- -- -- -- --  ---------------  --------------------
  b0 00 da 00 00 00 00 00 c2 4f 00 00 80  1d+05:35:05.200  SMART RETURN STATUS
  b0 00 d1 00 01 00 00 00 c2 4f 00 00 80  1d+05:35:05.200  SMART READ ATTRIBUTE THRESHOLDS [OBS-4]
  b0 00 d0 00 01 00 00 00 c2 4f 00 00 80  1d+05:35:05.200  SMART READ DATA
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80  1d+05:35:05.200  IDENTIFY DEVICE
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80  1d+05:35:05.100  IDENTIFY DEVICE

Error 1 [0] occurred at disk power-on lifetime: 2210 hours (92 days + 2 hours)
  When the command that caused the error occurred, the device was in an unknown state.

  After command completion occurred, registers were:
  ER -- ST COUNT  LBA_48  LH LM LL DV DC
  -- -- -- == -- == == == -- -- -- -- --
  84 -- 41 00 08 00 00 01 06 03 60 40 00

  Commands leading to the command that caused the error were:
  CR FEATR COUNT  LBA_48  LH LM LL DV DC  Powered_Up_Time  Command/Feature_Name
  -- == -- == -- == == == -- -- -- -- --  ---------------  --------------------
  06 00 01 00 01 00 00 00 00 00 00 00 80     20:58:08.800  DATA SET MANAGEMENT
  b0 00 da 00 00 00 00 00 c2 4f 00 00 80     20:57:17.100  SMART RETURN STATUS
  b0 00 d1 00 01 00 00 00 c2 4f 00 00 80     20:57:17.100  SMART READ ATTRIBUTE THRESHOLDS [OBS-4]
  b0 00 d0 00 01 00 00 00 c2 4f 00 00 80     20:57:17.100  SMART READ DATA
  ec 00 00 00 01 00 00 00 c2 4f 00 00 80     20:57:17.100  IDENTIFY DEVICE

SMART Extended Self-test Log Version: 1 (1 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     13567         -
# 2  Short offline       Completed without error       00%     10585         -
# 3  Short offline       Completed without error       00%     10585         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       1 (0x0001)
Device State:                        Active (0)
Current Temperature:                    33 Celsius
Power Cycle Min/Max Temperature:      ?/34 Celsius
Lifetime    Min/Max Temperature:      ?/ ? Celsius
Under/Over Temperature Limit Count:   0/0

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:     -127/127 Celsius
Min/Max Temperature Limit:           -127/127 Celsius
Temperature History Size (Index):    478 (304)

Index    Estimated Time   Temperature Celsius
 305    2026-01-05 11:06    35  ****************
 ...    ..(  2 skipped).    ..  ****************
 308    2026-01-05 11:09    35  ****************
 309    2026-01-05 11:10    34  ***************
 310    2026-01-05 11:11    36  *****************
 311    2026-01-05 11:12    35  ****************
 312    2026-01-05 11:13    35  ****************
 313    2026-01-05 11:14    36  *****************
 314    2026-01-05 11:15    35  ****************
 ...    ..(  3 skipped).    ..  ****************
 318    2026-01-05 11:19    35  ****************
 319    2026-01-05 11:20    36  *****************
 320    2026-01-05 11:21    35  ****************
 321    2026-01-05 11:22    35  ****************
 322    2026-01-05 11:23    35  ****************
 323    2026-01-05 11:24    36  *****************
 324    2026-01-05 11:25    35  ****************
 325    2026-01-05 11:26    35  ****************
 326    2026-01-05 11:27    36  *****************
 327    2026-01-05 11:28    35  ****************
 ...    ..(  4 skipped).    ..  ****************
 332    2026-01-05 11:33    35  ****************
 333    2026-01-05 11:34    36  *****************
 334    2026-01-05 11:35    35  ****************
 335    2026-01-05 11:36    35  ****************
 336    2026-01-05 11:37    36  *****************
 337    2026-01-05 11:38    36  *****************
 338    2026-01-05 11:39    36  *****************
 339    2026-01-05 11:40    35  ****************
 340    2026-01-05 11:41    36  *****************
 341    2026-01-05 11:42    35  ****************
 342    2026-01-05 11:43    35  ****************
 343    2026-01-05 11:44    36  *****************
 344    2026-01-05 11:45    35  ****************
 345    2026-01-05 11:46    35  ****************
 346    2026-01-05 11:47    36  *****************
 347    2026-01-05 11:48    35  ****************
 ...    ..(  7 skipped).    ..  ****************
 355    2026-01-05 11:56    35  ****************
 356    2026-01-05 11:57    36  *****************
 357    2026-01-05 11:58    35  ****************
 ...    ..(  6 skipped).    ..  ****************
 364    2026-01-05 12:05    35  ****************
 365    2026-01-05 12:06    36  *****************
 366    2026-01-05 12:07    35  ****************
 ...    ..(  3 skipped).    ..  ****************
 370    2026-01-05 12:11    35  ****************
 371    2026-01-05 12:12    36  *****************
 372    2026-01-05 12:13    35  ****************
 ...    ..(  2 skipped).    ..  ****************
 375    2026-01-05 12:16    35  ****************
 376    2026-01-05 12:17    36  *****************
 377    2026-01-05 12:18    35  ****************
 378    2026-01-05 12:19    35  ****************
 379    2026-01-05 12:20    36  *****************
 380    2026-01-05 12:21    36  *****************
 381    2026-01-05 12:22    35  ****************
 382    2026-01-05 12:23    35  ****************
 383    2026-01-05 12:24    36  *****************
 384    2026-01-05 12:25    35  ****************
 385    2026-01-05 12:26    35  ****************
 386    2026-01-05 12:27    36  *****************
 387    2026-01-05 12:28    35  ****************
 388    2026-01-05 12:29    36  *****************
 389    2026-01-05 12:30    35  ****************
 390    2026-01-05 12:31    35  ****************
 391    2026-01-05 12:32    36  *****************
 392    2026-01-05 12:33    35  ****************
 393    2026-01-05 12:34    36  *****************
 394    2026-01-05 12:35    39  ********************
 395    2026-01-05 12:36    35  ****************
 ...    ..(  3 skipped).    ..  ****************
 399    2026-01-05 12:40    35  ****************
 400    2026-01-05 12:41    36  *****************
 401    2026-01-05 12:42    35  ****************
 402    2026-01-05 12:43    35  ****************
 403    2026-01-05 12:44    35  ****************
 404    2026-01-05 12:45    34  ***************
 405    2026-01-05 12:46    35  ****************
 ...    ..(  6 skipped).    ..  ****************
 412    2026-01-05 12:53    35  ****************
 413    2026-01-05 12:54    34  ***************
 414    2026-01-05 12:55    35  ****************
 ...    ..(  4 skipped).    ..  ****************
 419    2026-01-05 13:00    35  ****************
 420    2026-01-05 13:01    36  *****************
 421    2026-01-05 13:02    35  ****************
 422    2026-01-05 13:03    36  *****************
 423    2026-01-05 13:04    36  *****************
 424    2026-01-05 13:05    36  *****************
 425    2026-01-05 13:06    35  ****************
 426    2026-01-05 13:07    35  ****************
 427    2026-01-05 13:08    35  ****************
 428    2026-01-05 13:09    36  *****************
 429    2026-01-05 13:10    35  ****************
 430    2026-01-05 13:11    35  ****************
 431    2026-01-05 13:12    36  *****************
 432    2026-01-05 13:13    35  ****************
 433    2026-01-05 13:14    36  *****************
 434    2026-01-05 13:15    35  ****************
 435    2026-01-05 13:16    36  *****************
 436    2026-01-05 13:17    35  ****************
 437    2026-01-05 13:18    35  ****************
 438    2026-01-05 13:19    36  *****************
 439    2026-01-05 13:20    35  ****************
 440    2026-01-05 13:21    36  *****************
 441    2026-01-05 13:22    36  *****************
 442    2026-01-05 13:23    35  ****************
 443    2026-01-05 13:24    36  *****************
 444    2026-01-05 13:25    36  *****************
 445    2026-01-05 13:26    35  ****************
 446    2026-01-05 13:27    36  *****************
 ...    ..(  4 skipped).    ..  *****************
 451    2026-01-05 13:32    36  *****************
 452    2026-01-05 13:33    34  ***************
 453    2026-01-05 13:34    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 456    2026-01-05 13:37    36  *****************
 457    2026-01-05 13:38    35  ****************
 458    2026-01-05 13:39    36  *****************
 459    2026-01-05 13:40    36  *****************
 460    2026-01-05 13:41    36  *****************
 461    2026-01-05 13:42    35  ****************
 462    2026-01-05 13:43    36  *****************
 463    2026-01-05 13:44    35  ****************
 464    2026-01-05 13:45    36  *****************
 465    2026-01-05 13:46    35  ****************
 466    2026-01-05 13:47    36  *****************
 467    2026-01-05 13:48    35  ****************
 468    2026-01-05 13:49    36  *****************
 469    2026-01-05 13:50    37  ******************
 470    2026-01-05 13:51    36  *****************
 ...    ..(  5 skipped).    ..  *****************
 476    2026-01-05 13:57    36  *****************
 477    2026-01-05 13:58    35  ****************
   0    2026-01-05 13:59    35  ****************
   1    2026-01-05 14:00    36  *****************
 ...    ..(  3 skipped).    ..  *****************
   5    2026-01-05 14:04    36  *****************
   6    2026-01-05 14:05    35  ****************
   7    2026-01-05 14:06    35  ****************
   8    2026-01-05 14:07    36  *****************
 ...    ..(  5 skipped).    ..  *****************
  14    2026-01-05 14:13    36  *****************
  15    2026-01-05 14:14    35  ****************
  16    2026-01-05 14:15    36  *****************
  17    2026-01-05 14:16    36  *****************
  18    2026-01-05 14:17    36  *****************
  19    2026-01-05 14:18    37  ******************
  20    2026-01-05 14:19    36  *****************
 ...    ..(  2 skipped).    ..  *****************
  23    2026-01-05 14:22    36  *****************
  24    2026-01-05 14:23    35  ****************
  25    2026-01-05 14:24    35  ****************
  26    2026-01-05 14:25    36  *****************
  27    2026-01-05 14:26    36  *****************
  28    2026-01-05 14:27    37  ******************
  29    2026-01-05 14:28    36  *****************
 ...    ..(  4 skipped).    ..  *****************
  34    2026-01-05 14:33    36  *****************
  35    2026-01-05 14:34    35  ****************
  36    2026-01-05 14:35    36  *****************
 ...    ..( 12 skipped).    ..  *****************
  49    2026-01-05 14:48    36  *****************
  50    2026-01-05 14:49    35  ****************
  51    2026-01-05 14:50    36  *****************
 ...    ..(  9 skipped).    ..  *****************
  61    2026-01-05 15:00    36  *****************
  62    2026-01-05 15:01    38  *******************
  63    2026-01-05 15:02    38  *******************
  64    2026-01-05 15:03    36  *****************
 ...    ..(  4 skipped).    ..  *****************
  69    2026-01-05 15:08    36  *****************
  70    2026-01-05 15:09    35  ****************
  71    2026-01-05 15:10    36  *****************
  72    2026-01-05 15:11    36  *****************
  73    2026-01-05 15:12    36  *****************
  74    2026-01-05 15:13    35  ****************
  75    2026-01-05 15:14    36  *****************
 ...    ..( 11 skipped).    ..  *****************
  87    2026-01-05 15:26    36  *****************
  88    2026-01-05 15:27    35  ****************
  89    2026-01-05 15:28    36  *****************
 ...    ..(  7 skipped).    ..  *****************
  97    2026-01-05 15:36    36  *****************
  98    2026-01-05 15:37    37  ******************
  99    2026-01-05 15:38    36  *****************
 100    2026-01-05 15:39    35  ****************
 101    2026-01-05 15:40    39  ********************
 102    2026-01-05 15:41    36  *****************
 103    2026-01-05 15:42    35  ****************
 104    2026-01-05 15:43    36  *****************
 ...    ..( 16 skipped).    ..  *****************
 121    2026-01-05 16:00    36  *****************
 122    2026-01-05 16:01    35  ****************
 123    2026-01-05 16:02    36  *****************
 ...    ..( 15 skipped).    ..  *****************
 139    2026-01-05 16:18    36  *****************
 140    2026-01-05 16:19    35  ****************
 141    2026-01-05 16:20    36  *****************
 ...    ..(  3 skipped).    ..  *****************
 145    2026-01-05 16:24    36  *****************
 146    2026-01-05 16:25    34  ***************
 147    2026-01-05 16:26    36  *****************
 148    2026-01-05 16:27    35  ****************
 149    2026-01-05 16:28    36  *****************
 150    2026-01-05 16:29    34  ***************
 151    2026-01-05 16:30    35  ****************
 152    2026-01-05 16:31    35  ****************
 153    2026-01-05 16:32    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 156    2026-01-05 16:35    36  *****************
 157    2026-01-05 16:36    35  ****************
 158    2026-01-05 16:37    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 161    2026-01-05 16:40    36  *****************
 162    2026-01-05 16:41    35  ****************
 163    2026-01-05 16:42    35  ****************
 164    2026-01-05 16:43    37  ******************
 165    2026-01-05 16:44    36  *****************
 166    2026-01-05 16:45    34  ***************
 167    2026-01-05 16:46    36  *****************
 ...    ..( 15 skipped).    ..  *****************
 183    2026-01-05 17:02    36  *****************
 184    2026-01-05 17:03    35  ****************
 185    2026-01-05 17:04    33  **************
 186    2026-01-05 17:05    36  *****************
 187    2026-01-05 17:06    35  ****************
 188    2026-01-05 17:07    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 191    2026-01-05 17:10    36  *****************
 192    2026-01-05 17:11    37  ******************
 193    2026-01-05 17:12    36  *****************
 194    2026-01-05 17:13    36  *****************
 195    2026-01-05 17:14    36  *****************
 196    2026-01-05 17:15    35  ****************
 197    2026-01-05 17:16    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 200    2026-01-05 17:19    36  *****************
 201    2026-01-05 17:20    34  ***************
 202    2026-01-05 17:21    36  *****************
 ...    ..( 16 skipped).    ..  *****************
 219    2026-01-05 17:38    36  *****************
 220    2026-01-05 17:39    35  ****************
 221    2026-01-05 17:40    36  *****************
 222    2026-01-05 17:41    36  *****************
 223    2026-01-05 17:42    36  *****************
 224    2026-01-05 17:43    35  ****************
 ...    ..(  2 skipped).    ..  ****************
 227    2026-01-05 17:46    35  ****************
 228    2026-01-05 17:47    36  *****************
 ...    ..(  2 skipped).    ..  *****************
 231    2026-01-05 17:50    36  *****************
 232    2026-01-05 17:51    35  ****************
 233    2026-01-05 17:52    36  *****************
 234    2026-01-05 17:53    35  ****************
 235    2026-01-05 17:54    36  *****************
 236    2026-01-05 17:55    35  ****************
 237    2026-01-05 17:56    36  *****************
 238    2026-01-05 17:57    36  *****************
 239    2026-01-05 17:58    36  *****************
 240    2026-01-05 17:59    35  ****************
 241    2026-01-05 18:00     ?  -
 242    2026-01-05 18:01     ?  -
 243    2026-01-05 18:02    35  ****************
 244    2026-01-05 18:03    36  *****************
 245    2026-01-05 18:04    35  ****************
 246    2026-01-05 18:05    35  ****************
 247    2026-01-05 18:06    36  *****************
 248    2026-01-05 18:07    36  *****************
 249    2026-01-05 18:08     ?  -
 250    2026-01-05 18:09    35  ****************
 251    2026-01-05 18:10    36  *****************
 ...    ..(  7 skipped).    ..  *****************
 259    2026-01-05 18:18    36  *****************
 260    2026-01-05 18:19     ?  -
 261    2026-01-05 18:20    36  *****************
 262    2026-01-05 18:21    36  *****************
 263    2026-01-05 18:22    38  *******************
 264    2026-01-05 18:23    35  ****************
 265    2026-01-05 18:24    35  ****************
 266    2026-01-05 18:25     ?  -
 267    2026-01-05 18:26     ?  -
 268    2026-01-05 18:27    35  ****************
 269    2026-01-05 18:28    35  ****************
 270    2026-01-05 18:29    35  ****************
 271    2026-01-05 18:30    34  ***************
 272    2026-01-05 18:31    34  ***************
 273    2026-01-05 18:32    34  ***************
 274    2026-01-05 18:33     ?  -
 275    2026-01-05 18:34     ?  -
 276    2026-01-05 18:35    33  **************
 277    2026-01-05 18:36    34  ***************
 278    2026-01-05 18:37     ?  -
 279    2026-01-05 18:38     ?  -
 280    2026-01-05 18:39     ?  -
 281    2026-01-05 18:40    34  ***************
 282    2026-01-05 18:41    35  ****************
 283    2026-01-05 18:42    34  ***************
 284    2026-01-05 18:43    34  ***************
 285    2026-01-05 18:44    34  ***************
 286    2026-01-05 18:45    33  **************
 ...    ..(  4 skipped).    ..  **************
 291    2026-01-05 18:50    33  **************
 292    2026-01-05 18:51    35  ****************
 293    2026-01-05 18:52    33  **************
 294    2026-01-05 18:53    33  **************
 295    2026-01-05 18:54    33  **************
 296    2026-01-05 18:55    34  ***************
 297    2026-01-05 18:56    34  ***************
 298    2026-01-05 18:57    33  **************
 ...    ..(  2 skipped).    ..  **************
 301    2026-01-05 19:00    33  **************
 302    2026-01-05 19:01    32  *************
 303    2026-01-05 19:02    33  **************
 304    2026-01-05 19:03    33  **************

SCT Error Recovery Control command not supported

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4             161  -D-  Lifetime Power-On Resets
0x01  0x010  4           14043  -D-  Power-on Hours
0x01  0x018  6      1516344684  -D-  Logical Sectors Written
0x01  0x020  6        84469942  -D-  Number of Write Commands
0x01  0x028  6      1268518720  -D-  Logical Sectors Read
0x01  0x030  6        64704527  -D-  Number of Read Commands
0x01  0x038  6  11499593266232  -D-  Date and Time TimeStamp
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1              50  ND-  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            4  Command failed due to ICRC error
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
0x0008  2            0  Device-to-host non-data FIS retries
0x0009  4            0  Transition from drive PhyRdy to drive PhyNRdy
0x000a  4           32  Device-to-host register FISes sent due to a COMRESET
0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC
```