### PR TITLE
Always set HUP signal handler

### DIFF
--- a/src/smartd.cpp
+++ b/src/smartd.cpp
@@ -102,10 +102,7 @@ static void set_signal(int sig, signal_handler_type handler)
 
 #else
   // SVr4, POSIX.1-2001, ..., POSIX.1-2024
-  struct sigaction sa;
-  sa.sa_handler = SIG_DFL;
-  sigaction(sig, (struct sigaction *)0, &sa);
-  sa = {};
+  struct sigaction sa = {};
   sa.sa_handler = handler;
   sa.sa_flags = SA_RESTART; // BSD signal() semantics
   sigaction(sig, &sa, (struct sigaction *)0);


### PR DESCRIPTION
This PR addresses FreeBSD bug [293205](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293205), which is about smartd ignoring HUP signal when started at boot. The root cause is that `/etc/rc` is a non-interactive shell, so the smartd process inherits `SIG_IGN` for `HUP`, and the `HUP` signal handler is never set. 

The initial logic of the `set_signal_if_not_ignored` was valid: the first implementation only showed a warning and exited, so if HUP was intentionally ignored, it did not terminate the process by respecting the SIG_IGN flag. Later, `smartd` got a fully functional HUP handler, but the logic was never changed; moreover, it was extended to other signals. This PR removes the SIG_IGN check, so `smartd` listens to HUP regardless. Could be easily tested with `nohup smartd` and `killall -HUP smartd` or `procstat` output.

