### PR TITLE
drivedb.h: Silicon Motion based USB SSDs (TS1TESD310C/W0807BMO)

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2599,7 +2599,7 @@ const drive_settings builtin_knowndrives[] = {
     "-v 251,raw48,Unkn_SiliconMotion_Attr" // ADATA SU800/Q0913A
   },
   { "Silicon Motion based USB SSDs",
-    "TS((128|256|512)G|[12]T)ESD310[CPS]", // Transcend ESD310, tested with TS1TESD310C/W0807BMO (0x2174:2100)
+    "TS((128|256|512)G|[12]T)ESD310[CPS]", // Transcend ESD310, tested with TS1TESD310C/W0807BMO (0x2174:0x2100)
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
   //"-v 9,raw24(raw8),Power_On_Hours "


### PR DESCRIPTION
Fixes #520, trac ticket [1767](https://www.smartmontools.org/ticket/1767).

Capacities are from the [ESD310 product sheet](https://us.transcend-info.com/product/portable-ssd/esd310). This [review](https://www.tweaktown.com/reviews/10517/transcend-esd310c-1tb-pen-drive-ssd-dual-ports-of-awesomeness/index.html) says it uses a Silicon Motion SM2320 native USB controller so perhaps unsurprisingly its attributes, according to the Transcend tool, mostly matches `Silicon Motion based SSDs` apart from 244-246.

As an aside, the Silicon Power DS72 from #509 is a better match for this entry once these attributes are added:
```C
    "-v 160,raw48,Uncorrectable_Error_Cnt "
    "-v 163,raw48,Initial_Bad_Block_Count "
    "-v 164,raw48,Total_Erase_Count "
    "-v 165,raw48,Max_Erase_Count "
    "-v 166,raw48,Min_Erase_Count "
    "-v 167,raw48,Average_Erase_Count "
    "-v 168,raw48,Max_Erase_Count_of_Spec "
    "-v 173,raw48,Unkn_SiliconMotion_Attr " // SP DS72/Y0328A00
  //"-v 182,raw48,Erase_Fail_Count_Total "
```
This 2025 [review](https://www.everythingusb.com/dual-flash-drives.html) says that it also uses an SM2320 controller. However, this 2024 [review](https://www.ixbt.com/data/silicon-power-ds72-ms60-ms70-500gb-review.html) says it uses a Phison U17 controller though with a different firmware `UHFM00.6`, perhaps that's an earlier revision of the product.

I can move that to this entry with another commit here, if that's acceptable.