### PR TITLE
drivedb.h: Fujitsu MJA2 BH: Fix attributes

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -3084,9 +3084,13 @@ const drive_settings builtin_knowndrives[] = {
     "FUJITSU MHZ2(08|12|16|25)0BK.*",
     "", "", ""
   },
-  { "Fujitsu MJA BH",
+  { "Fujitsu MJA2 BH", // tested with FUJITSU MJA2500BH G2/00000018
     "FUJITSU MJA2(08|12|16|25|32|40|50)0BH.*",
-    "", "", ""
+    "", "",
+    "-v 2,raw16 "
+    "-v 195,raw48,ECC_On_the_Fly_Count "
+    "-v 200,raw48,Write_Error_Rate "
+    "-v 240,raw48,Transfer_Error_Rate"
   },
   { "", // Samsung SV4012H (known firmware)
     "SAMSUNG SV4012H",


### PR DESCRIPTION
Renamed from MJA BH and fix attributes 2, 195, 200, and 240.

Based on the log in #534.

The Fujitsu [press release](https://www.fujitsu.com/global/about/resources/news/press-releases/2008/1111-01.html) from November 2008 refers to this as the "MJA2 BH series". The attributes are from page 5-60 of the [maintenance manual](https://www.manualslib.com/manual/547591/Fujitsu-Mja2500bh-Mobile-500-Gb-Hard-Drive.html#product-MJA2160BH) and match other Fujitsu drives like the MHW2 BH and MHZ2 BJ G1.