### PR TITLE
drivedb.h: SandForce Driven SSDs: ADATA DP900, Axiom Signature Sr III

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -929,6 +929,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "SandForce Driven SSDs",
     "SandForce 1st Ed\\.|" // Demo Drive, tested with firmware 320A13F0
+    "ADATA SSD DP900 (64|128|256|512)GB-DL3|" // tested with ADATA SSD DP900 256GB-DL3/5.8.2
     "ADATA SSD S(396|510|599) .?..GB|" // tested with ADATA SSD S510 60GB/320ABBF0,
       // ADATA SSD S599 256GB/3.1.0, 64GB/3.4.6
     "ADATA SP[389]00|" // tested with ADATA SP300/5.0.2d, SP800/5.0.6c,
@@ -937,6 +938,7 @@ const drive_settings builtin_knowndrives[] = {
       // ADATA SSD SX900 512GB-DL2/5.8.2
     "ADATA XM11 (128|256)GB|" // tested with ADATA XM11 128GB/5.0.1
     "ATP Velocity MIV (60|120|240|480)GB|" // tested with ATP Velocity MIV 480GB/110719
+    "Axiom Signature Series III SSD|" // tested with Axiom Signature Series III SSD/606ABBF0
     "Comay BladeDrive E28 (800|1600|3200)GB|" // LSI SF-2581, tested with Comay BladeDrive E28 800GB/2.71
     "Corsair CSSD-F(40|60|80|115|120|160|240)GBP?2.*|" // Corsair Force, tested with
       // Corsair CSSD-F40GB2/1.1, Corsair CSSD-F115GB2-A/2.1a
@@ -1030,6 +1032,7 @@ const drive_settings builtin_knowndrives[] = {
     "-v 184,raw48,IO_Error_Detect_Code_Ct "
   //"-v 187,raw48,Reported_Uncorrect "
     "-v 189,tempminmax,Airflow_Temperature_Cel "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
   //"-v 192,raw48,Power-Off_Retract_Count "
   //"-v 194,tempminmax,Temperature_Celsius "
     "-v 195,raw24/raw32,ECC_Uncorr_Error_Count "


### PR DESCRIPTION
Add ADATA SSD DP900 256GB-DL3/5.8.2

Fixes trac ticket [1936](https://www.smartmontools.org/ticket/1936).

Add Axiom Signature Series III SSD/606ABBF0

Fixes trac ticket [1669](https://www.smartmontools.org/ticket/1669).

ADATA DP900 capacities based on SP900.