### PR TITLE
drivedb.h: Silicon Motion based USB SSDs: ADATA SE880/W0928BR0

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2522,7 +2522,6 @@ const drive_settings builtin_knowndrives[] = {
     "SED2QII-LP SATA SSD ((64|128|256|512)GB|[12]TB)|" // ACPI SED2QII-LP, tested with
       // SED2QII-LP SATA SSD 64GB/S0410A
     "SH00M(120|240|480)GB|" // Yucun R580, tested with SH00M120GB/R0817A0
-    "SP DS72|" // Silicon Power DS72, tested with SP DS72/Y0328A00 (2TB) (0x090c:0x2320)
     "T60|" // KingSpec T60, tested with T60/20151120
     "TCSUNBOW [MX]3 (60|120|240|480)GB|" // TC-Sunbow M3/X3, tested with TCSUNBOW M3 240GB/R0327B0,
       // TCSUNBOW X3 120GB/R1211A0, TCSUNBOW X3 480GB/S0509A0
@@ -2575,8 +2574,6 @@ const drive_settings builtin_knowndrives[] = {
     "-v 167,raw48,Average_Erase_Count "
     "-v 168,raw48,Max_Erase_Count_of_Spec "
     "-v 169,raw48,Remaining_Lifetime_Perc "
-    "-v 172,raw48,Unkn_SiliconMotion_Attr " // SP DS72/Y0328A00
-    "-v 173,raw48,Unkn_SiliconMotion_Attr " // SP DS72/Y0328A00
   //"-v 175,raw48,Program_Fail_Count_Chip "
   //"-v 176,raw48,Erase_Fail_Count_Chip "
   //"-v 177,raw48,Wear_Leveling_Count "
@@ -2591,13 +2588,11 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 197,raw48,Current_Pending_Sector "
   //"-v 198,raw48,Offline_Uncorrectable "
   //"-v 199,raw48,UDMA_CRC_Error_Count "
-    "-v 218,raw48,Unkn_SiliconMotion_Attr " // SP DS72/Y0328A00
     "-v 225,raw48,Host_Writes_32MiB " // FW 20140402
     "-v 231,raw48,SSD_Life_Left " // KINGSTON SKC600256G/S4500105
   //"-v 232,raw48,Available_Reservd_Space "
     "-v 241,raw48,Host_Writes_32MiB "
     "-v 242,raw48,Host_Reads_32MiB "
-    "-v 244,raw48,Unkn_SiliconMotion_Attr " // SP DS72/Y0328A00
     "-v 245,raw48,TLC_Writes_32MiB " // FW N0815B, N1114H // TS128GMSA370I: Flash Write Sector Count
     "-v 246,raw48,SLC_Writes_32MiB "
     "-v 247,raw48,Raid_Recoverty_Ct "
@@ -2607,15 +2602,26 @@ const drive_settings builtin_knowndrives[] = {
     "-v 251,raw48,Unkn_SiliconMotion_Attr" // ADATA SU800/Q0913A
   },
   { "Silicon Motion based USB SSDs",
+    "ADATA SE880|" // tested with ADATA SE880/W0928BR0 (500GB) (0x090c:0xa11a)
+    "SP DS72|" // Silicon Power DS72, tested with SP DS72/Y0328A00 (2TB) (0x090c:0x2320)
     "TS((128|256|512)G|[12]T)ESD310[CPS]", // Transcend ESD310, tested with TS1TESD310C/W0807BMO (0x2174:0x2100)
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
   //"-v 9,raw24(raw8),Power_On_Hours "
   //"-v 12,raw48,Power_Cycle_Count "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
     "-v 161,raw48,Spare_Blocks_Remaining "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Max_Erase_Count_of_Spec "
     "-v 169,raw48,Remaining_Lifetime_Perc "
     "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Unkn_SiliconMotion_Attr " // ADATA SE880/W0928BR0, SP DS72/Y0328A00
   //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 182,raw48,Erase_Fail_Count_Total "
     "-v 187,raw48,Read_Fail_Count "
     "-v 192,raw48,Unexpect_Power_Loss_Cnt "
   //"-v 194,tempminmax,Temperature_Celsius "
@@ -2625,7 +2631,7 @@ const drive_settings builtin_knowndrives[] = {
     "-v 233,raw48,NAND_Writes_32MiB "
     "-v 241,raw48,Host_Writes_32MiB "
     "-v 242,raw48,Host_Reads_32MiB "
-    "-v 244,raw48,Avg_Erase_Count "
+    "-v 244,raw48,Average_Erase_Count "
     "-v 245,raw48,Max_Erase_Count "
     "-v 246,raw48,Total_Erase_Count "
   },


### PR DESCRIPTION
Closes: trac ticket [1975](https://www.smartmontools.org/ticket/1975)

Also move the SP DS72/Y0328A00 in #509 to this model family.