### PR TITLE
add mpi3 support for new generation broadcom raid controllers

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -99,6 +99,7 @@ EXTRA_libsmartmon_la_SOURCES = \
         netbsd_nvme_ioctl.h \
         openbsd_nvme_ioctl.h \
         megaraid.h \
+        mpi3mr.h \
         sssraid.h
 
 if OS_WIN32

--- a/lib/mpi3mr.h
+++ b/lib/mpi3mr.h
@@ -1,0 +1,397 @@
+/*
+ * mpi3mr.h
+ *
+ *
+ * Original Mpi3mr code:
+ *  Copyright (C) 2025 Alexandra Löber <a.loeber@de.leaseweb.com>
+ *  Copyright (C) 2025 Andreas Pelger <a.pelger@de.leaseweb.com>
+ *  Copyright (C) 2025 Tranquillity Codes <tranquillitycodes@proton.me>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#undef u32
+
+#define u8  uint8_t
+#define u16 uint16_t
+#define u32 uint32_t
+#define u64 uint64_t
+
+
+#define MPI3_POINTER    *
+
+/*****************************************************************************
+ *              Common structure for Simple, Chain, and Last Chain           *
+ *              scatter gather elements                                      *
+ ****************************************************************************/
+typedef struct _MPI3_SGE_COMMON
+{
+    u64             Address;                           /* 0x00 */
+    u32             Length;                            /* 0x08 */
+    u8              Reserved0C[3];                     /* 0x0C */
+    u8              Flags;                             /* 0x0F */
+} __attribute__ ((packed)) MPI3_SGE_SIMPLE, MPI3_POINTER PTR_MPI3_SGE_SIMPLE,
+  Mpi3SGESimple_t, MPI3_POINTER pMpi3SGESimple_t,
+  MPI3_SGE_CHAIN, MPI3_POINTER PTR_MPI3_SGE_CHAIN,
+  Mpi3SGEChain_t, MPI3_POINTER pMpi3SGEChain_t,
+  MPI3_SGE_LAST_CHAIN, MPI3_POINTER PTR_MPI3_SGE_LAST_CHAIN,
+  Mpi3SGELastChain_t, MPI3_POINTER pMpi3SGELastChain_t;
+
+/*****************************************************************************
+ *              Union of scatter gather elements                             *
+ ****************************************************************************/
+typedef union _MPI3_SGE_UNION
+{
+    MPI3_SGE_SIMPLE                 Simple;
+    u32                             Words[4];
+} __attribute__ ((packed)) MPI3_SGE_UNION, MPI3_POINTER PTR_MPI3_SGE_UNION,
+  Mpi3SGEUnion_t, MPI3_POINTER pMpi3SGEUnion_t;
+
+/**
+ * @brief MPI reply buffer definition
+ *
+ */
+
+typedef struct _SL8_MPI_REPLY_BUF{
+    u8 mpiRepType;
+    u8 reserved[3];
+} __attribute__ ((packed)) SL8_MPI_REPLY_BUF;
+
+
+/*****************************************************************************
+ *              SCSI IO Error Reply Message                                  *
+ ****************************************************************************/
+typedef struct _MPI3_SCSI_IO_REPLY
+{
+    u16                     HostTag;                        /* 0x00 */
+    u8                      IOCUseOnly02;                   /* 0x02 */
+    u8                      Function;                       /* 0x03 */
+    u16                     IOCUseOnly04;                   /* 0x04 */
+    u8                      IOCUseOnly06;                   /* 0x06 */
+    u8                      MsgFlags;                       /* 0x07 */
+    u16                     IOCUseOnly08;                   /* 0x08 */
+    u16                     IOCStatus;                      /* 0x0A */
+    u32                     IOCLogInfo;                     /* 0x0C */
+    u8                      SCSIStatus;                     /* 0x10 */
+    u8                      SCSIState;                      /* 0x11 */
+    u16                     DevHandle;                      /* 0x12 */
+    u32                     TransferCount;                  /* 0x14 */
+    u32                     SenseCount;                     /* 0x18 */
+    u32                     ResponseData;                   /* 0x1C */
+    u16                     TaskTag;                        /* 0x20 */
+    u16                     SCSIStatusQualifier;            /* 0x22 */
+    u32                     EEDPErrorOffset;                /* 0x24 */
+    u16                     EEDPObservedAppTag;             /* 0x28 */
+    u16                     EEDPObservedGuard;              /* 0x2A */
+    u32                     EEDPObservedRefTag;             /* 0x2C */
+    u64                     SenseDataBufferAddress;         /* 0x30 */
+} __attribute__ ((packed)) MPI3_SCSI_IO_REPLY, MPI3_POINTER PTR_MPI3_SCSI_IO_REPLY,
+  Mpi3SCSIIOReply_t, MPI3_POINTER pMpi3SCSIIOReply_t;
+
+/**
+ * struct mpi3mr_bsg_drv_cmd -  Generic bsg data
+ * structure for all driver specific requests.
+ *
+ * @mrioc_id: Controller ID
+ * @opcode: Driver specific opcode
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ */
+struct mpi3mr_bsg_drv_cmd {
+    u8    mrioc_id;
+    u8    opcode;
+    u16   rsvd1;
+    u32   rsvd2[4];
+};
+
+/**
+ * struct mpi3mr_bsg_in_reply_buf - MPI reply buffer returned
+ * for MPI Passthrough request .
+ *
+ * @mpi_reply_type: Type of MPI reply
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ * @reply_buf: Variable Length buffer based on mpirep type
+ */
+struct mpi3mr_bsg_in_reply_buf {
+    u8    mpi_reply_type;
+    u8    rsvd1;
+    u16   rsvd2;
+    u8    reply_buf[];
+};
+
+/**
+ * struct mpi3mr_buf_entry - User buffer descriptor for MPI
+ * Passthrough requests.
+ *
+ * @buf_type: Buffer type
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ * @buf_len: Buffer length
+ */
+struct mpi3mr_buf_entry {
+    u8    buf_type;
+    u8    rsvd1;
+    u16   rsvd2;
+    u32   buf_len;
+};
+
+/**
+ * struct mpi3mr_bsg_buf_entry_list - list of user buffer
+ * descriptor for MPI Passthrough requests.
+ *
+ * @num_of_entries: Number of buffer descriptors
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ * @rsvd3: Reserved
+ * @buf_entry: Variable length array of buffer descriptors
+ */
+struct mpi3mr_buf_entry_list {
+    u8    num_of_entries;
+    u8    rsvd1;
+    u16   rsvd2;
+    u32   rsvd3;
+    struct mpi3mr_buf_entry buf_entry[1];
+};
+
+/**
+ * struct mpi3mr_bsg_mptcmd -  Generic bsg data
+ * structure for all MPI Passthrough requests .
+ *
+ * @mrioc_id: Controller ID
+ * @rsvd1: Reserved
+ * @timeout: MPI request timeout
+ * @buf_entry_list: Buffer descriptor list
+ */
+struct mpi3mr_bsg_mptcmd {
+    u8    mrioc_id;
+    u8    rsvd1;
+    u16   timeout;
+    u32   rsvd2;
+    struct mpi3mr_buf_entry_list buf_entry_list;
+};
+
+/**
+ * struct mpi3mr_bsg_packet -  Generic bsg data
+ * structure for all supported requests .
+ *
+ * @cmd_type: represents drvrcmd or mptcmd
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ * @drvrcmd: driver request structure
+ * @mptcmd: mpt request structure
+ */
+struct mpi3mr_bsg_packet {
+    u8    cmd_type;
+    u8    rsvd1;
+    u16   rsvd2;
+    u32   rsvd3;
+    union {
+        struct mpi3mr_bsg_drv_cmd drvrcmd;
+        struct mpi3mr_bsg_mptcmd mptcmd;
+    } cmd;
+};
+
+/**
+ * struct mpi3mr_device_map_info - Target device mapping
+ * information
+ *
+ * @handle: Firmware device handle
+ * @perst_id: Persistent ID assigned by the firmware
+ * @target_id: Target ID assigned by the driver
+ * @bus_id: Bus ID assigned by the driver
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ */
+struct mpi3mr_device_map_info {
+    u16   handle;
+    u16   perst_id;
+    u32   target_id;
+    u8    bus_id;
+    u8    rsvd1;
+    u16   rsvd2;
+};
+
+/**
+ * struct mpi3mr_all_tgt_info - Target device mapping
+ * information returned by the driver
+ *
+ * @num_devices: The number of devices in driver's inventory
+ * @rsvd1: Reserved
+ * @rsvd2: Reserved
+ * @dmi: Variable length array of mapping information of targets
+ */
+struct mpi3mr_all_tgt_info {
+    u16   num_devices;
+    u16   rsvd1;
+    u32   rsvd2;
+    struct mpi3mr_device_map_info dmi[1];
+};
+
+struct mpi3_scsi_io_cdb_eedp32 {
+    u8                 cdb[20];
+    u32             primary_reference_tag;
+    u16             primary_application_tag;
+    u16             primary_application_tag_mask;
+    u32             transfer_length;
+} __attribute__ ((packed));
+
+struct mpi3_sge_common {
+    u64             address;
+    u32             length;
+    u8                 reserved0c[3];
+    u8                 flags;
+} __attribute__ ((packed));
+
+union mpi3_scsi_io_cdb_union {
+    u8                         cdb32[32];
+    struct mpi3_scsi_io_cdb_eedp32 eedp32;
+    struct mpi3_sge_common         sge;
+} __attribute__ ((packed));
+
+struct mpi3_scsi_io_request {
+    u16                     host_tag;
+    u8                         ioc_use_only02;
+    u8                         function;
+    u16                     ioc_use_only04;
+    u8                         ioc_use_only06;
+    u8                         msg_flags;
+    u16                     change_count;
+    u16                     dev_handle;
+    u32                     flags;
+    u32                     skip_count;
+    u32                     data_length;
+    u8                         lun[8];
+    union mpi3_scsi_io_cdb_union  cdb;
+    MPI3_SGE_UNION          sgl[4];
+} __attribute__ ((packed));
+
+#define MPI3_SCSIIO_MSGFLAGS_METASGL_VALID                  (0x80)
+#define MPI3_SCSIIO_MSGFLAGS_DIVERT_TO_FIRMWARE             (0x40)
+
+#define MPI3_SCSIIO_FLAGS_LARGE_CDB                         (0x60000000)
+#define MPI3_SCSIIO_FLAGS_CDB_16_OR_LESS                    (0x00000000)
+#define MPI3_SCSIIO_FLAGS_CDB_GREATER_THAN_16               (0x20000000)
+#define MPI3_SCSIIO_FLAGS_CDB_IN_SEPARATE_BUFFER            (0x40000000)
+#define MPI3_SCSIIO_FLAGS_TASKATTRIBUTE_MASK                (0x07000000)
+#define MPI3_SCSIIO_FLAGS_TASKATTRIBUTE_SIMPLEQ             (0x00000000)
+#define MPI3_SCSIIO_FLAGS_TASKATTRIBUTE_HEADOFQ             (0x01000000)
+#define MPI3_SCSIIO_FLAGS_TASKATTRIBUTE_ORDEREDQ            (0x02000000)
+#define MPI3_SCSIIO_FLAGS_TASKATTRIBUTE_ACAQ                (0x04000000)
+#define MPI3_SCSIIO_FLAGS_CMDPRI_MASK                       (0x00f00000)
+#define MPI3_SCSIIO_FLAGS_CMDPRI_SHIFT                      (20)
+#define MPI3_SCSIIO_FLAGS_DATADIRECTION_MASK                (0x000c0000)
+#define MPI3_SCSIIO_FLAGS_DATADIRECTION_NO_DATA_TRANSFER    (0x00000000)
+#define MPI3_SCSIIO_FLAGS_DATADIRECTION_WRITE               (0x00040000)
+#define MPI3_SCSIIO_FLAGS_DATADIRECTION_READ                (0x00080000)
+#define MPI3_SCSIIO_FLAGS_DMAOPERATION_MASK                 (0x00030000)
+#define MPI3_SCSIIO_FLAGS_DMAOPERATION_HOST_PI              (0x00010000)
+#define MPI3_SCSIIO_FLAGS_DIVERT_REASON_MASK                (0x000000f0)
+#define MPI3_SCSIIO_FLAGS_DIVERT_REASON_IO_THROTTLING       (0x00000010)
+#define MPI3_SCSIIO_FLAGS_DIVERT_REASON_WRITE_SAME_TOO_LARGE (0x00000020)
+#define MPI3_SCSIIO_FLAGS_DIVERT_REASON_PROD_SPECIFIC       (0x00000080)
+
+struct mpi3_scsi_io_reply {
+    u16                     host_tag;
+    u8                         ioc_use_only02;
+    u8                         function;
+    u16                     ioc_use_only04;
+    u8                         ioc_use_only06;
+    u8                         msg_flags;
+    u16                     ioc_use_only08;
+    u16                     ioc_status;
+    u32                     ioc_log_info;
+    u8                         scsi_status;
+    u8                         scsi_state;
+    u16                     dev_handle;
+    u32                     transfer_count;
+    u32                     sense_count;
+    u32                     response_data;
+    u16                     task_tag;
+    u16                     scsi_status_qualifier;
+    u32                     eedp_error_offset;
+    u16                     eedp_observed_app_tag;
+    u16                     eedp_observed_guard;
+    u32                     eedp_observed_ref_tag;
+    u64                     sense_data_buffer_address;
+} __attribute__ ((packed));
+
+
+/* Definitions for BSG commands */
+#define MPI3MR_IOCTL_VERSION            0x06
+
+#define MPI3MR_APP_DEFAULT_TIMEOUT      (60) /*seconds*/
+
+#define MPI3MR_BSG_ADPTYPE_UNKNOWN      0
+#define MPI3MR_BSG_ADPTYPE_AVGFAMILY        1
+
+#define MPI3MR_BSG_ADPSTATE_UNKNOWN     0
+#define MPI3MR_BSG_ADPSTATE_OPERATIONAL     1
+#define MPI3MR_BSG_ADPSTATE_FAULT       2
+#define MPI3MR_BSG_ADPSTATE_IN_RESET        3
+#define MPI3MR_BSG_ADPSTATE_UNRECOVERABLE   4
+
+#define MPI3MR_BSG_ADPRESET_UNKNOWN     0
+#define MPI3MR_BSG_ADPRESET_SOFT        1
+#define MPI3MR_BSG_ADPRESET_DIAG_FAULT      2
+
+#define MPI3MR_BSG_LOGDATA_MAX_ENTRIES      400
+#define MPI3MR_BSG_LOGDATA_ENTRY_HEADER_SZ  4
+
+#define MPI3MR_DRVBSG_OPCODE_UNKNOWN        0
+#define MPI3MR_DRVBSG_OPCODE_ADPINFO        1
+#define MPI3MR_DRVBSG_OPCODE_ADPRESET       2
+#define MPI3MR_DRVBSG_OPCODE_ALLTGTDEVINFO  4
+#define MPI3MR_DRVBSG_OPCODE_GETCHGCNT      5
+#define MPI3MR_DRVBSG_OPCODE_LOGDATAENABLE  6
+#define MPI3MR_DRVBSG_OPCODE_PELENABLE      7
+#define MPI3MR_DRVBSG_OPCODE_GETLOGDATA     8
+#define MPI3MR_DRVBSG_OPCODE_QUERY_HDB      9
+#define MPI3MR_DRVBSG_OPCODE_REPOST_HDB     10
+#define MPI3MR_DRVBSG_OPCODE_UPLOAD_HDB     11
+#define MPI3MR_DRVBSG_OPCODE_REFRESH_HDB_TRIGGERS   12
+
+
+#define MPI3MR_BSG_BUFTYPE_UNKNOWN      0
+#define MPI3MR_BSG_BUFTYPE_RAIDMGMT_CMD     1
+#define MPI3MR_BSG_BUFTYPE_RAIDMGMT_RESP    2
+#define MPI3MR_BSG_BUFTYPE_DATA_IN      3
+#define MPI3MR_BSG_BUFTYPE_DATA_OUT     4
+#define MPI3MR_BSG_BUFTYPE_MPI_REPLY        5
+#define MPI3MR_BSG_BUFTYPE_ERR_RESPONSE     6
+#define MPI3MR_BSG_BUFTYPE_MPI_REQUEST      0xFE
+
+#define MPI3MR_BSG_MPI_REPLY_BUFTYPE_UNKNOWN    0
+#define MPI3MR_BSG_MPI_REPLY_BUFTYPE_STATUS 1
+#define MPI3MR_BSG_MPI_REPLY_BUFTYPE_ADDRESS    2
+
+#define MPI3MR_HDB_BUFTYPE_UNKNOWN      0
+#define MPI3MR_HDB_BUFTYPE_TRACE        1
+#define MPI3MR_HDB_BUFTYPE_FIRMWARE     2
+#define MPI3MR_HDB_BUFTYPE_RESERVED     3
+
+#define MPI3MR_HDB_BUFSTATUS_UNKNOWN        0
+#define MPI3MR_HDB_BUFSTATUS_NOT_ALLOCATED  1
+#define MPI3MR_HDB_BUFSTATUS_POSTED_UNPAUSED    2
+#define MPI3MR_HDB_BUFSTATUS_POSTED_PAUSED  3
+#define MPI3MR_HDB_BUFSTATUS_RELEASED       4
+
+#define MPI3MR_HDB_TRIGGER_TYPE_UNKNOWN     0
+#define MPI3MR_HDB_TRIGGER_TYPE_DIAGFAULT   1
+#define MPI3MR_HDB_TRIGGER_TYPE_ELEMENT     2
+#define MPI3MR_HDB_TRIGGER_TYPE_MASTER      3
+
+#define MPI3_FUNCTION_MGMT_PASSTHROUGH              (0x0a)
+#define MPI3_FUNCTION_SCSI_IO                       (0x20)
+
+/* Supported BSG commands */
+enum command {
+    MPI3MR_DRV_CMD = 1,
+    MPI3MR_MPT_CMD = 2,
+};
+
+
+#undef u8
+#undef u16
+#undef u32
+#undef u64

--- a/lib/mpi3mr.h
+++ b/lib/mpi3mr.h
@@ -10,32 +10,24 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#undef u32
-
-#define u8  uint8_t
-#define u16 uint16_t
-#define u32 uint32_t
-#define u64 uint64_t
-
-
-#define MPI3_POINTER    *
-
 /*****************************************************************************
  *              Common structure for Simple, Chain, and Last Chain           *
  *              scatter gather elements                                      *
  ****************************************************************************/
 typedef struct _MPI3_SGE_COMMON
 {
-    u64             Address;                           /* 0x00 */
-    u32             Length;                            /* 0x08 */
-    u8              Reserved0C[3];                     /* 0x0C */
-    u8              Flags;                             /* 0x0F */
-} __attribute__ ((packed)) MPI3_SGE_SIMPLE, MPI3_POINTER PTR_MPI3_SGE_SIMPLE,
-  Mpi3SGESimple_t, MPI3_POINTER pMpi3SGESimple_t,
-  MPI3_SGE_CHAIN, MPI3_POINTER PTR_MPI3_SGE_CHAIN,
-  Mpi3SGEChain_t, MPI3_POINTER pMpi3SGEChain_t,
-  MPI3_SGE_LAST_CHAIN, MPI3_POINTER PTR_MPI3_SGE_LAST_CHAIN,
-  Mpi3SGELastChain_t, MPI3_POINTER pMpi3SGELastChain_t;
+    uint64_t             Address;                           /* 0x00 */
+    uint32_t             Length;                            /* 0x08 */
+    uint8_t              Reserved0C[3];                     /* 0x0C */
+    uint8_t              Flags;                             /* 0x0F */
+} __attribute__ ((packed)) MPI3_SGE_COMMON, * PTR_MPI3_SGE_COMMON,
+  MPI3_SGE_SIMPLE, * PTR_MPI3_SGE_SIMPLE,
+  Mpi3SGESimple_t, * pMpi3SGESimple_t,
+  MPI3_SGE_CHAIN, * PTR_MPI3_SGE_CHAIN,
+  Mpi3SGEChain_t, * pMpi3SGEChain_t,
+  MPI3_SGE_LAST_CHAIN, * PTR_MPI3_SGE_LAST_CHAIN,
+  Mpi3SGELastChain_t, * pMpi3SGELastChain_t;
+SMARTMON_ASSERT_SIZEOF(MPI3_SGE_COMMON, 16);
 
 /*****************************************************************************
  *              Union of scatter gather elements                             *
@@ -43,9 +35,10 @@ typedef struct _MPI3_SGE_COMMON
 typedef union _MPI3_SGE_UNION
 {
     MPI3_SGE_SIMPLE                 Simple;
-    u32                             Words[4];
-} __attribute__ ((packed)) MPI3_SGE_UNION, MPI3_POINTER PTR_MPI3_SGE_UNION,
-  Mpi3SGEUnion_t, MPI3_POINTER pMpi3SGEUnion_t;
+    uint32_t                             Words[4];
+} __attribute__ ((packed)) MPI3_SGE_UNION, * PTR_MPI3_SGE_UNION,
+  Mpi3SGEUnion_t, * pMpi3SGEUnion_t;
+SMARTMON_ASSERT_SIZEOF(MPI3_SGE_UNION, 16);
 
 /**
  * @brief MPI reply buffer definition
@@ -53,40 +46,41 @@ typedef union _MPI3_SGE_UNION
  */
 
 typedef struct _SL8_MPI_REPLY_BUF{
-    u8 mpiRepType;
-    u8 reserved[3];
+    uint8_t mpiRepType;
+    uint8_t reserved[3];
 } __attribute__ ((packed)) SL8_MPI_REPLY_BUF;
-
+SMARTMON_ASSERT_SIZEOF(SL8_MPI_REPLY_BUF, 4);
 
 /*****************************************************************************
  *              SCSI IO Error Reply Message                                  *
  ****************************************************************************/
 typedef struct _MPI3_SCSI_IO_REPLY
 {
-    u16                     HostTag;                        /* 0x00 */
-    u8                      IOCUseOnly02;                   /* 0x02 */
-    u8                      Function;                       /* 0x03 */
-    u16                     IOCUseOnly04;                   /* 0x04 */
-    u8                      IOCUseOnly06;                   /* 0x06 */
-    u8                      MsgFlags;                       /* 0x07 */
-    u16                     IOCUseOnly08;                   /* 0x08 */
-    u16                     IOCStatus;                      /* 0x0A */
-    u32                     IOCLogInfo;                     /* 0x0C */
-    u8                      SCSIStatus;                     /* 0x10 */
-    u8                      SCSIState;                      /* 0x11 */
-    u16                     DevHandle;                      /* 0x12 */
-    u32                     TransferCount;                  /* 0x14 */
-    u32                     SenseCount;                     /* 0x18 */
-    u32                     ResponseData;                   /* 0x1C */
-    u16                     TaskTag;                        /* 0x20 */
-    u16                     SCSIStatusQualifier;            /* 0x22 */
-    u32                     EEDPErrorOffset;                /* 0x24 */
-    u16                     EEDPObservedAppTag;             /* 0x28 */
-    u16                     EEDPObservedGuard;              /* 0x2A */
-    u32                     EEDPObservedRefTag;             /* 0x2C */
-    u64                     SenseDataBufferAddress;         /* 0x30 */
-} __attribute__ ((packed)) MPI3_SCSI_IO_REPLY, MPI3_POINTER PTR_MPI3_SCSI_IO_REPLY,
-  Mpi3SCSIIOReply_t, MPI3_POINTER pMpi3SCSIIOReply_t;
+    uint16_t                     HostTag;                        /* 0x00 */
+    uint8_t                      IOCUseOnly02;                   /* 0x02 */
+    uint8_t                      Function;                       /* 0x03 */
+    uint16_t                     IOCUseOnly04;                   /* 0x04 */
+    uint8_t                      IOCUseOnly06;                   /* 0x06 */
+    uint8_t                      MsgFlags;                       /* 0x07 */
+    uint16_t                     IOCUseOnly08;                   /* 0x08 */
+    uint16_t                     IOCStatus;                      /* 0x0A */
+    uint32_t                     IOCLogInfo;                     /* 0x0C */
+    uint8_t                      SCSIStatus;                     /* 0x10 */
+    uint8_t                      SCSIState;                      /* 0x11 */
+    uint16_t                     DevHandle;                      /* 0x12 */
+    uint32_t                     TransferCount;                  /* 0x14 */
+    uint32_t                     SenseCount;                     /* 0x18 */
+    uint32_t                     ResponseData;                   /* 0x1C */
+    uint16_t                     TaskTag;                        /* 0x20 */
+    uint16_t                     SCSIStatusQualifier;            /* 0x22 */
+    uint32_t                     EEDPErrorOffset;                /* 0x24 */
+    uint16_t                     EEDPObservedAppTag;             /* 0x28 */
+    uint16_t                     EEDPObservedGuard;              /* 0x2A */
+    uint32_t                     EEDPObservedRefTag;             /* 0x2C */
+    uint64_t                     SenseDataBufferAddress;         /* 0x30 */
+} __attribute__ ((packed)) MPI3_SCSI_IO_REPLY, * PTR_MPI3_SCSI_IO_REPLY,
+  Mpi3SCSIIOReply_t, * pMpi3SCSIIOReply_t;
+SMARTMON_ASSERT_SIZEOF(MPI3_SCSI_IO_REPLY, 56);
 
 /**
  * struct mpi3mr_bsg_drv_cmd -  Generic bsg data
@@ -98,11 +92,12 @@ typedef struct _MPI3_SCSI_IO_REPLY
  * @rsvd2: Reserved
  */
 struct mpi3mr_bsg_drv_cmd {
-    u8    mrioc_id;
-    u8    opcode;
-    u16   rsvd1;
-    u32   rsvd2[4];
+    uint8_t    mrioc_id;
+    uint8_t    opcode;
+    uint16_t   rsvd1;
+    uint32_t   rsvd2[4];
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_bsg_drv_cmd, 20);
 
 /**
  * struct mpi3mr_bsg_in_reply_buf - MPI reply buffer returned
@@ -114,11 +109,12 @@ struct mpi3mr_bsg_drv_cmd {
  * @reply_buf: Variable Length buffer based on mpirep type
  */
 struct mpi3mr_bsg_in_reply_buf {
-    u8    mpi_reply_type;
-    u8    rsvd1;
-    u16   rsvd2;
-    u8    reply_buf[];
+    uint8_t    mpi_reply_type;
+    uint8_t    rsvd1;
+    uint16_t   rsvd2;
+    uint8_t    reply_buf[];
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_bsg_in_reply_buf, 4);
 
 /**
  * struct mpi3mr_buf_entry - User buffer descriptor for MPI
@@ -130,11 +126,12 @@ struct mpi3mr_bsg_in_reply_buf {
  * @buf_len: Buffer length
  */
 struct mpi3mr_buf_entry {
-    u8    buf_type;
-    u8    rsvd1;
-    u16   rsvd2;
-    u32   buf_len;
+    uint8_t    buf_type;
+    uint8_t    rsvd1;
+    uint16_t   rsvd2;
+    uint32_t   buf_len;
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_buf_entry, 8);
 
 /**
  * struct mpi3mr_bsg_buf_entry_list - list of user buffer
@@ -147,12 +144,13 @@ struct mpi3mr_buf_entry {
  * @buf_entry: Variable length array of buffer descriptors
  */
 struct mpi3mr_buf_entry_list {
-    u8    num_of_entries;
-    u8    rsvd1;
-    u16   rsvd2;
-    u32   rsvd3;
+    uint8_t    num_of_entries;
+    uint8_t    rsvd1;
+    uint16_t   rsvd2;
+    uint32_t   rsvd3;
     struct mpi3mr_buf_entry buf_entry[1];
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_buf_entry_list, 16);
 
 /**
  * struct mpi3mr_bsg_mptcmd -  Generic bsg data
@@ -164,12 +162,13 @@ struct mpi3mr_buf_entry_list {
  * @buf_entry_list: Buffer descriptor list
  */
 struct mpi3mr_bsg_mptcmd {
-    u8    mrioc_id;
-    u8    rsvd1;
-    u16   timeout;
-    u32   rsvd2;
+    uint8_t    mrioc_id;
+    uint8_t    rsvd1;
+    uint16_t   timeout;
+    uint32_t   rsvd2;
     struct mpi3mr_buf_entry_list buf_entry_list;
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_bsg_mptcmd, 24);
 
 /**
  * struct mpi3mr_bsg_packet -  Generic bsg data
@@ -182,15 +181,16 @@ struct mpi3mr_bsg_mptcmd {
  * @mptcmd: mpt request structure
  */
 struct mpi3mr_bsg_packet {
-    u8    cmd_type;
-    u8    rsvd1;
-    u16   rsvd2;
-    u32   rsvd3;
+    uint8_t    cmd_type;
+    uint8_t    rsvd1;
+    uint16_t   rsvd2;
+    uint32_t   rsvd3;
     union {
         struct mpi3mr_bsg_drv_cmd drvrcmd;
         struct mpi3mr_bsg_mptcmd mptcmd;
     } cmd;
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_bsg_packet, 32);
 
 /**
  * struct mpi3mr_device_map_info - Target device mapping
@@ -204,13 +204,14 @@ struct mpi3mr_bsg_packet {
  * @rsvd2: Reserved
  */
 struct mpi3mr_device_map_info {
-    u16   handle;
-    u16   perst_id;
-    u32   target_id;
-    u8    bus_id;
-    u8    rsvd1;
-    u16   rsvd2;
+    uint16_t   handle;
+    uint16_t   perst_id;
+    uint32_t   target_id;
+    uint8_t    bus_id;
+    uint8_t    rsvd1;
+    uint16_t   rsvd2;
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_device_map_info, 12);
 
 /**
  * struct mpi3mr_all_tgt_info - Target device mapping
@@ -222,46 +223,50 @@ struct mpi3mr_device_map_info {
  * @dmi: Variable length array of mapping information of targets
  */
 struct mpi3mr_all_tgt_info {
-    u16   num_devices;
-    u16   rsvd1;
-    u32   rsvd2;
+    uint16_t   num_devices;
+    uint16_t   rsvd1;
+    uint32_t   rsvd2;
     struct mpi3mr_device_map_info dmi[1];
 };
+SMARTMON_ASSERT_SIZEOF(mpi3mr_all_tgt_info, 20);
 
 struct mpi3_scsi_io_cdb_eedp32 {
-    u8                 cdb[20];
-    u32             primary_reference_tag;
-    u16             primary_application_tag;
-    u16             primary_application_tag_mask;
-    u32             transfer_length;
+    uint8_t                 cdb[20];
+    uint32_t             primary_reference_tag;
+    uint16_t             primary_application_tag;
+    uint16_t             primary_application_tag_mask;
+    uint32_t             transfer_length;
 } __attribute__ ((packed));
+SMARTMON_ASSERT_SIZEOF(mpi3_scsi_io_cdb_eedp32, 32);
 
 struct mpi3_sge_common {
-    u64             address;
-    u32             length;
-    u8                 reserved0c[3];
-    u8                 flags;
+    uint64_t             address;
+    uint32_t             length;
+    uint8_t                 reserved0c[3];
+    uint8_t                 flags;
 } __attribute__ ((packed));
+SMARTMON_ASSERT_SIZEOF(mpi3_sge_common, 16);
 
 union mpi3_scsi_io_cdb_union {
-    u8                         cdb32[32];
+    uint8_t                         cdb32[32];
     struct mpi3_scsi_io_cdb_eedp32 eedp32;
     struct mpi3_sge_common         sge;
 } __attribute__ ((packed));
+SMARTMON_ASSERT_SIZEOF(mpi3_scsi_io_cdb_union, 32);
 
 struct mpi3_scsi_io_request {
-    u16                     host_tag;
-    u8                         ioc_use_only02;
-    u8                         function;
-    u16                     ioc_use_only04;
-    u8                         ioc_use_only06;
-    u8                         msg_flags;
-    u16                     change_count;
-    u16                     dev_handle;
-    u32                     flags;
-    u32                     skip_count;
-    u32                     data_length;
-    u8                         lun[8];
+    uint16_t                     host_tag;
+    uint8_t                         ioc_use_only02;
+    uint8_t                         function;
+    uint16_t                     ioc_use_only04;
+    uint8_t                         ioc_use_only06;
+    uint8_t                         msg_flags;
+    uint16_t                     change_count;
+    uint16_t                     dev_handle;
+    uint32_t                     flags;
+    uint32_t                     skip_count;
+    uint32_t                     data_length;
+    uint8_t                         lun[8];
     union mpi3_scsi_io_cdb_union  cdb;
     MPI3_SGE_UNION          sgl[4];
 } __attribute__ ((packed));
@@ -292,29 +297,30 @@ struct mpi3_scsi_io_request {
 #define MPI3_SCSIIO_FLAGS_DIVERT_REASON_PROD_SPECIFIC       (0x00000080)
 
 struct mpi3_scsi_io_reply {
-    u16                     host_tag;
-    u8                         ioc_use_only02;
-    u8                         function;
-    u16                     ioc_use_only04;
-    u8                         ioc_use_only06;
-    u8                         msg_flags;
-    u16                     ioc_use_only08;
-    u16                     ioc_status;
-    u32                     ioc_log_info;
-    u8                         scsi_status;
-    u8                         scsi_state;
-    u16                     dev_handle;
-    u32                     transfer_count;
-    u32                     sense_count;
-    u32                     response_data;
-    u16                     task_tag;
-    u16                     scsi_status_qualifier;
-    u32                     eedp_error_offset;
-    u16                     eedp_observed_app_tag;
-    u16                     eedp_observed_guard;
-    u32                     eedp_observed_ref_tag;
-    u64                     sense_data_buffer_address;
+    uint16_t                     host_tag;
+    uint8_t                         ioc_use_only02;
+    uint8_t                         function;
+    uint16_t                     ioc_use_only04;
+    uint8_t                         ioc_use_only06;
+    uint8_t                         msg_flags;
+    uint16_t                     ioc_use_only08;
+    uint16_t                     ioc_status;
+    uint32_t                     ioc_log_info;
+    uint8_t                         scsi_status;
+    uint8_t                         scsi_state;
+    uint16_t                     dev_handle;
+    uint32_t                     transfer_count;
+    uint32_t                     sense_count;
+    uint32_t                     response_data;
+    uint16_t                     task_tag;
+    uint16_t                     scsi_status_qualifier;
+    uint32_t                     eedp_error_offset;
+    uint16_t                     eedp_observed_app_tag;
+    uint16_t                     eedp_observed_guard;
+    uint32_t                     eedp_observed_ref_tag;
+    uint64_t                     sense_data_buffer_address;
 } __attribute__ ((packed));
+SMARTMON_ASSERT_SIZEOF(mpi3_scsi_io_reply, 56);
 
 
 /* Definitions for BSG commands */
@@ -322,47 +328,47 @@ struct mpi3_scsi_io_reply {
 
 #define MPI3MR_APP_DEFAULT_TIMEOUT      (60) /*seconds*/
 
-#define MPI3MR_BSG_ADPTYPE_UNKNOWN      0
+#define MPI3MR_BSG_ADPTYPE_UNKNOWN          0
 #define MPI3MR_BSG_ADPTYPE_AVGFAMILY        1
 
-#define MPI3MR_BSG_ADPSTATE_UNKNOWN     0
+#define MPI3MR_BSG_ADPSTATE_UNKNOWN         0
 #define MPI3MR_BSG_ADPSTATE_OPERATIONAL     1
-#define MPI3MR_BSG_ADPSTATE_FAULT       2
+#define MPI3MR_BSG_ADPSTATE_FAULT           2
 #define MPI3MR_BSG_ADPSTATE_IN_RESET        3
 #define MPI3MR_BSG_ADPSTATE_UNRECOVERABLE   4
 
-#define MPI3MR_BSG_ADPRESET_UNKNOWN     0
-#define MPI3MR_BSG_ADPRESET_SOFT        1
+#define MPI3MR_BSG_ADPRESET_UNKNOWN         0
+#define MPI3MR_BSG_ADPRESET_SOFT            1
 #define MPI3MR_BSG_ADPRESET_DIAG_FAULT      2
 
 #define MPI3MR_BSG_LOGDATA_MAX_ENTRIES      400
 #define MPI3MR_BSG_LOGDATA_ENTRY_HEADER_SZ  4
 
-#define MPI3MR_DRVBSG_OPCODE_UNKNOWN        0
-#define MPI3MR_DRVBSG_OPCODE_ADPINFO        1
-#define MPI3MR_DRVBSG_OPCODE_ADPRESET       2
-#define MPI3MR_DRVBSG_OPCODE_ALLTGTDEVINFO  4
-#define MPI3MR_DRVBSG_OPCODE_GETCHGCNT      5
-#define MPI3MR_DRVBSG_OPCODE_LOGDATAENABLE  6
-#define MPI3MR_DRVBSG_OPCODE_PELENABLE      7
-#define MPI3MR_DRVBSG_OPCODE_GETLOGDATA     8
-#define MPI3MR_DRVBSG_OPCODE_QUERY_HDB      9
-#define MPI3MR_DRVBSG_OPCODE_REPOST_HDB     10
-#define MPI3MR_DRVBSG_OPCODE_UPLOAD_HDB     11
+#define MPI3MR_DRVBSG_OPCODE_UNKNOWN                0
+#define MPI3MR_DRVBSG_OPCODE_ADPINFO                1
+#define MPI3MR_DRVBSG_OPCODE_ADPRESET               2
+#define MPI3MR_DRVBSG_OPCODE_ALLTGTDEVINFO          4
+#define MPI3MR_DRVBSG_OPCODE_GETCHGCNT              5
+#define MPI3MR_DRVBSG_OPCODE_LOGDATAENABLE          6
+#define MPI3MR_DRVBSG_OPCODE_PELENABLE              7
+#define MPI3MR_DRVBSG_OPCODE_GETLOGDATA             8
+#define MPI3MR_DRVBSG_OPCODE_QUERY_HDB              9
+#define MPI3MR_DRVBSG_OPCODE_REPOST_HDB             10
+#define MPI3MR_DRVBSG_OPCODE_UPLOAD_HDB             11
 #define MPI3MR_DRVBSG_OPCODE_REFRESH_HDB_TRIGGERS   12
 
 
-#define MPI3MR_BSG_BUFTYPE_UNKNOWN      0
+#define MPI3MR_BSG_BUFTYPE_UNKNOWN          0
 #define MPI3MR_BSG_BUFTYPE_RAIDMGMT_CMD     1
 #define MPI3MR_BSG_BUFTYPE_RAIDMGMT_RESP    2
-#define MPI3MR_BSG_BUFTYPE_DATA_IN      3
-#define MPI3MR_BSG_BUFTYPE_DATA_OUT     4
+#define MPI3MR_BSG_BUFTYPE_DATA_IN          3
+#define MPI3MR_BSG_BUFTYPE_DATA_OUT         4
 #define MPI3MR_BSG_BUFTYPE_MPI_REPLY        5
 #define MPI3MR_BSG_BUFTYPE_ERR_RESPONSE     6
 #define MPI3MR_BSG_BUFTYPE_MPI_REQUEST      0xFE
 
 #define MPI3MR_BSG_MPI_REPLY_BUFTYPE_UNKNOWN    0
-#define MPI3MR_BSG_MPI_REPLY_BUFTYPE_STATUS 1
+#define MPI3MR_BSG_MPI_REPLY_BUFTYPE_STATUS     1
 #define MPI3MR_BSG_MPI_REPLY_BUFTYPE_ADDRESS    2
 
 #define MPI3MR_HDB_BUFTYPE_UNKNOWN      0
@@ -370,11 +376,11 @@ struct mpi3_scsi_io_reply {
 #define MPI3MR_HDB_BUFTYPE_FIRMWARE     2
 #define MPI3MR_HDB_BUFTYPE_RESERVED     3
 
-#define MPI3MR_HDB_BUFSTATUS_UNKNOWN        0
-#define MPI3MR_HDB_BUFSTATUS_NOT_ALLOCATED  1
+#define MPI3MR_HDB_BUFSTATUS_UNKNOWN            0
+#define MPI3MR_HDB_BUFSTATUS_NOT_ALLOCATED      1
 #define MPI3MR_HDB_BUFSTATUS_POSTED_UNPAUSED    2
-#define MPI3MR_HDB_BUFSTATUS_POSTED_PAUSED  3
-#define MPI3MR_HDB_BUFSTATUS_RELEASED       4
+#define MPI3MR_HDB_BUFSTATUS_POSTED_PAUSED      3
+#define MPI3MR_HDB_BUFSTATUS_RELEASED           4
 
 #define MPI3MR_HDB_TRIGGER_TYPE_UNKNOWN     0
 #define MPI3MR_HDB_TRIGGER_TYPE_DIAGFAULT   1
@@ -389,9 +395,3 @@ enum command {
     MPI3MR_DRV_CMD = 1,
     MPI3MR_MPT_CMD = 2,
 };
-
-
-#undef u8
-#undef u16
-#undef u32
-#undef u64

--- a/lib/os_linux.cpp
+++ b/lib/os_linux.cpp
@@ -4124,7 +4124,8 @@ smart_device * linux_smart_interface::get_custom_smart_device(const char * name,
 
   // mpi3mr
   int n = -1;
-  if (sscanf(type, "mpi3mr,%d%n", &disknum, &n) == 1 && n == (int)strlen(type)) {
+  size_t type_len = (type ? strlen(type) : 0);
+  if (sscanf(type, "mpi3mr,%d%n", &disknum, &n) == 1 && n == (int)type_len) {
     return new linux_mpi3mr_device(this, name, disknum);
   }
 

--- a/lib/os_linux.cpp
+++ b/lib/os_linux.cpp
@@ -17,6 +17,11 @@
  * Original MegaRAID code:
  *  Copyright (C) 2008    Jordan Hargrave <jordan_hargrave@dell.com>
  *
+ * Original Mpi3mr code:
+ *  Copyright (C) 2025 Alexandra Löber <a.loeber@de.leaseweb.com>
+ *  Copyright (C) 2025 Andreas Pelger <a.pelger@de.leaseweb.com>
+ *  Copyright (C) 2025 Tranquillity Codes <tranquillitycodes@proton.me>
+ *
  * 3ware code was derived from code that was:
  *
  *  Written By: Adam Radford <linux@3ware.com>
@@ -73,6 +78,7 @@
 #include <smartmon/utility.h>
 #include "cciss.h"
 #include "megaraid.h"
+#include "mpi3mr.h"
 #include "sssraid.h"
 #include "aacraid.h"
 #include <smartmon/nvmecmds.h>
@@ -1380,6 +1386,462 @@ bool linux_megaraid_device::megadev_cmd(int cdbLen, void *cdb,
                    uio.pthru.scsistatus);
   }
   return true;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+/// MPI3MR support
+
+class linux_mpi3mr_device
+: public /* implements */ scsi_device,
+  public /* extends */ linux_smart_device
+{
+
+public:
+  linux_mpi3mr_device(smart_interface *intf, const char *dev_name,
+    unsigned int tgt);
+
+  virtual ~linux_mpi3mr_device();
+
+  virtual smart_device * autodetect_open() override;
+
+  virtual bool open() override;
+  virtual bool close() override;
+
+  virtual bool scsi_pass_through(scsi_cmnd_io *iop) override;
+  static int get_mrioc_id(int bus_no);
+  static int mpi3mr_dev_list_cmd(int mrioc_id, void *buf,
+    size_t bufsize,int mpi3ctl_fd);
+
+private:
+  unsigned int m_disknum;
+  unsigned int m_hba;
+  unsigned int m_diskhandle = (unsigned int)-1;
+  unsigned int m_mrioc_id = (unsigned int)-1;
+  int m_fd;
+
+  bool mpi3mr_cmd(int cdbLen, void *cdb, int dataLen,
+    void *data, int senseLen,void *sense, int report, int dxfer_dir);
+  unsigned int mpi3mr_get_devhandle(int mrioc_id, unsigned int disknum);
+};
+
+linux_mpi3mr_device::linux_mpi3mr_device(smart_interface *intf,
+  const char *dev_name, unsigned int tgt)
+  : smart_device(intf, dev_name, "mpi3mr", "mpi3mr"),
+  linux_smart_device(O_RDWR | O_NONBLOCK),
+  m_disknum(tgt),
+  m_hba(-1), m_fd(-1)
+{
+  set_info().info_name = strprintf("%s [mpi3mr_disk_%02d]", dev_name, m_disknum);
+  set_info().dev_type = strprintf("mpi3mr,%d", tgt);
+}
+
+linux_mpi3mr_device::~linux_mpi3mr_device()
+{
+  close();
+  if (m_fd >= 0)
+    ::close(m_fd);
+}
+
+smart_device * linux_mpi3mr_device::autodetect_open()
+{
+  int report = scsi_debugmode;
+
+  // Open device
+  if (!open())
+    return this;
+
+  // The code below is based on smartd.cpp:SCSIFilterKnown()
+  if (strcmp(get_req_type(), "mpi3mr"))
+    return this;
+
+  // Get INQUIRY
+  unsigned char req_buff[64] = {0, };
+  int req_len = 36;
+  if (scsiStdInquiry(this, req_buff, req_len)) {
+      close();
+      set_err(EIO, "INQUIRY failed");
+      return this;
+  }
+
+  int avail_len = req_buff[4] + 5;
+  int len = (avail_len < req_len ? avail_len : req_len);
+  if (len < 36)
+      return this;
+
+  if (report)
+    lib_printf("Got MPI3MR inquiry.. %s\n", req_buff+8);
+
+  // Use INQUIRY to detect type
+  {
+    // SAT?
+    ata_device * newdev = smi()->autodetect_sat_device(this, req_buff, len);
+    if (newdev) // NOTE: 'this' is now owned by '*newdev'
+      return newdev;
+  }
+
+  // Nothing special found
+  return this;
+}
+
+bool linux_mpi3mr_device::open()
+{
+  int report = scsi_debugmode;
+  char  mpi3_fname[128] = {0};
+  bool  mpi3mr_found = false;
+  FILE * fp = NULL;
+
+  if (sscanf(get_dev_name(), "/dev/bus/%u", &m_hba) == 0) {
+  if (!linux_smart_device::open())
+    return false;
+  /* Get device HBA */
+  struct sg_scsi_id sgid;
+  if (ioctl(get_fd(), SG_GET_SCSI_ID, &sgid) == 0) {
+    m_hba = sgid.host_no;
+  }
+  else if (ioctl(get_fd(), SCSI_IOCTL_GET_BUS_NUMBER, &m_hba) != 0) {
+    int err = errno;
+    linux_smart_device::close();
+    return set_err(err, "can't get bus number");
+  } // we don't need this device anymore
+  linux_smart_device::close();
+  }
+
+  // check if the bus-number corresponds to mpi3mr driver
+  char sysfsfile[128] = {0};
+  snprintf(sysfsfile, sizeof(sysfsfile) - 1,
+  "/sys/class/scsi_host/host%u/proc_name", m_hba);
+  if((fp = fopen(sysfsfile, "r")) != NULL) {
+  char line[128] = {0};
+  // check if it is using mpi3mr
+  if(fgets(line, sizeof(line), fp) != NULL && !strncmp(line,"mpi3mr",6))
+    mpi3mr_found = true;
+  fclose(fp);
+  } else {
+    if(report > 0)
+    lib_printf("cannot open %s, err %d\n",sysfsfile, errno);
+  }
+
+  if (mpi3mr_found == true) {
+  m_mrioc_id = get_mrioc_id(m_hba);
+  sprintf(mpi3_fname, "/dev/bsg/mpi3mrctl%d", m_mrioc_id);
+  if ((m_fd = ::open(mpi3_fname, O_RDWR)) >= 0) {
+    set_fd(m_fd);
+  }
+  else {
+    int err = errno;
+    return set_err(err, "cannot open %s", mpi3_fname);
+  }
+  }
+  else {
+  return set_err(false, "mpi3mr driver not related to bus %d", m_hba);
+  }
+
+  return true;
+}
+
+int
+linux_mpi3mr_device::get_mrioc_id(int bus_no)
+{
+  int mrioc_id = -1;
+  char sysfsfile[128] = {0};
+  char line[64] = {0};
+  FILE * fp = NULL;
+
+  snprintf(sysfsfile, sizeof(sysfsfile) - 1,
+  "/sys/class/scsi_host/host%u/unique_id", bus_no);
+  if((fp = fopen(sysfsfile, "r")) == NULL)
+    return (mrioc_id);
+  if(fgets(line, sizeof(line), fp) != NULL)
+    mrioc_id=atoi(line);
+  fclose(fp);
+  return (mrioc_id);
+}
+
+int
+linux_mpi3mr_device::mpi3mr_dev_list_cmd(int mrioc_id, void *buf,
+  size_t bufsize, int mpi3ctl_fd)
+{
+    struct mpi3mr_bsg_packet *bsg_req = NULL;
+    struct sg_io_v4 io_hdr_v4;
+    uint8_t sense_buffer[32] = { 0 };
+    uint32_t din_buffers_size = bufsize;
+    uint8_t *sgl_din_base_ptr = (uint8_t*)buf;
+    uint32_t bsg_req_len=0;
+
+    if (buf == NULL || bufsize == 0 || mpi3ctl_fd < 0)    {
+      errno = EINVAL;
+      return (-errno);
+    }
+
+    // bsg_packet memory allocation
+    bsg_req_len = sizeof(struct mpi3mr_bsg_packet);
+    bsg_req = (struct mpi3mr_bsg_packet *)malloc(bsg_req_len);
+    if (!bsg_req)
+      throw std::bad_alloc();
+
+    bsg_req->cmd.drvrcmd.mrioc_id = mrioc_id;
+    bsg_req->cmd.drvrcmd.opcode = MPI3MR_DRVBSG_OPCODE_ALLTGTDEVINFO;
+    bsg_req->cmd_type = MPI3MR_DRV_CMD;
+
+    // clean up the previous data
+    memset(&io_hdr_v4, 0,sizeof(io_hdr_v4));
+    io_hdr_v4.guard = 'Q';
+    io_hdr_v4.protocol = BSG_PROTOCOL_SCSI;
+    io_hdr_v4.subprotocol = BSG_SUB_PROTOCOL_SCSI_TRANSPORT;
+    io_hdr_v4.response = (uint64_t)sense_buffer;
+    io_hdr_v4.max_response_len = sizeof(sense_buffer);
+    io_hdr_v4.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
+    io_hdr_v4.request = (uint64_t)bsg_req;
+    io_hdr_v4.request_len = sizeof(struct mpi3mr_bsg_packet);
+    io_hdr_v4.din_xferp = (uint64_t)sgl_din_base_ptr;
+    io_hdr_v4.din_xfer_len = din_buffers_size;
+
+    int r = ioctl(mpi3ctl_fd, SG_IO, &io_hdr_v4);
+    if (r < 0) {
+        lib_printf("IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
+        free(bsg_req);
+        return (r);
+    }
+
+    free(bsg_req);
+
+    return (0);
+}
+
+bool linux_mpi3mr_device::close()
+{
+  if (m_fd >= 0)
+    ::close(m_fd);
+  m_fd = -1;
+  set_fd(m_fd);
+  return true;
+}
+
+unsigned int
+linux_mpi3mr_device::mpi3mr_get_devhandle(int mrioc_id, unsigned int disknum)
+{
+  unsigned int devhandle = (unsigned int)-1;
+  uint32_t din_buffers_size=0x800;
+  uint8_t *sgl_din_base_ptr = NULL;
+  struct mpi3mr_all_tgt_info *drv_all_tgt_info = NULL;
+
+  /* get the devices from the driver to map the devh */
+  sgl_din_base_ptr = (uint8_t *)malloc(din_buffers_size);
+  if (!sgl_din_base_ptr)
+    throw std::bad_alloc();
+
+  if (mpi3mr_dev_list_cmd(mrioc_id, sgl_din_base_ptr, din_buffers_size, m_fd) < 0)    {
+  free(sgl_din_base_ptr);
+  return (devhandle);
+  }
+
+  // process the response
+  drv_all_tgt_info = (struct mpi3mr_all_tgt_info *)sgl_din_base_ptr;
+  for (int j = 0; j < drv_all_tgt_info->num_devices; j++) {
+    if(disknum == drv_all_tgt_info->dmi[j].perst_id) {
+      devhandle = drv_all_tgt_info->dmi[j].handle;
+      break;
+    }
+  }
+
+  free(sgl_din_base_ptr);
+
+  return (devhandle);
+}
+
+/* Issue passthrough scsi commands to MR8 controllers */
+bool
+linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
+  int dataLen, void *data,
+  int /*senseLen*/, void * /*sense*/, int /*report*/, int dxfer_dir)
+{
+  struct mpi3mr_bsg_packet *bsg_req = NULL;
+  struct sg_io_v4 io_hdr_v4;
+  uint8_t sense_buffer[32] = { 0 };
+  uint32_t dout_buffers_size=0, din_buffers_size=0;
+  uint8_t *sgl_din_base_ptr = NULL, *sgl_dout_base_ptr = NULL;
+  uint32_t bsg_buf_entry_list_size=0, bsg_req_len=0;
+  uint32_t i = 0, dir_flag = 0;
+  struct mpi3_scsi_io_request *mpi_scsi_req = NULL;
+  uint8_t in_buf = 2; // 1 MPI Resp + DATA_IN
+  uint8_t out_buf = 2; // 1 MPI Req + DATA_OUT
+
+  // get the mrioc_id for the bus, if not already known
+  if (m_mrioc_id == (unsigned int)-1) {
+    m_mrioc_id = get_mrioc_id(m_hba);
+    if (m_mrioc_id == (unsigned int)-1) {
+      return set_err(EINVAL, "Unknown / Invalid Bus Num %d\n", m_hba);
+    }
+  }
+
+  // get the devhandle for this device, if not already known
+  if (m_diskhandle == (unsigned int)-1) {
+    m_diskhandle = mpi3mr_get_devhandle(m_mrioc_id, m_disknum);
+    if (m_diskhandle == (unsigned int)-1) {
+      return set_err(EINVAL, "Unknown / Invalid disk %d\n", m_disknum);
+    }
+  }
+
+  switch (dxfer_dir) {
+    case DXFER_FROM_DEVICE:
+      din_buffers_size = dataLen;
+      dir_flag |= MPI3_SCSIIO_FLAGS_DATADIRECTION_READ;
+      break;
+    case DXFER_TO_DEVICE:
+      dout_buffers_size = dataLen;
+      dir_flag |= MPI3_SCSIIO_FLAGS_DATADIRECTION_WRITE;
+      break;
+    case DXFER_NONE:
+      dir_flag &= ~(MPI3_SCSIIO_FLAGS_DATADIRECTION_MASK);
+      break;
+    default:
+      return set_err(EINVAL, "mpi3mr_cmd: bad dxfer_dir");
+  }
+
+  bsg_buf_entry_list_size = sizeof(struct mpi3mr_buf_entry_list) + (sizeof(struct mpi3mr_buf_entry) * ((in_buf+out_buf)-1));
+
+  bsg_req_len = sizeof(struct mpi3mr_bsg_packet) + bsg_buf_entry_list_size;
+  bsg_req = (struct mpi3mr_bsg_packet *)malloc(bsg_req_len);
+  if (!bsg_req)
+    throw std::bad_alloc();
+
+  bsg_req->cmd.mptcmd.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
+  bsg_req->cmd_type = MPI3MR_MPT_CMD;
+  bsg_req->cmd.mptcmd.mrioc_id = m_mrioc_id;
+
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[0].buf_type = MPI3MR_BSG_BUFTYPE_MPI_REPLY;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[0].buf_len = sizeof(SL8_MPI_REPLY_BUF) + sizeof(MPI3_SCSI_IO_REPLY);
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[1].buf_type = MPI3MR_BSG_BUFTYPE_DATA_OUT;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[1].buf_len = dout_buffers_size;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[2].buf_type = MPI3MR_BSG_BUFTYPE_DATA_IN;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[2].buf_len = din_buffers_size;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[3].buf_type = MPI3MR_BSG_BUFTYPE_MPI_REQUEST;
+  bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[3].buf_len = sizeof(struct mpi3_scsi_io_request) - (4 * sizeof(MPI3_SGE_UNION));
+  bsg_req->cmd.mptcmd.buf_entry_list.num_of_entries = (in_buf+out_buf);
+
+  // get the total buffer size and allocate the memory
+  for(i = 0, dout_buffers_size = 0, din_buffers_size = 0; i < (in_buf+out_buf); i++) {
+    switch (bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[i].buf_type)   {
+      case MPI3MR_BSG_BUFTYPE_RAIDMGMT_CMD:
+      case MPI3MR_BSG_BUFTYPE_DATA_OUT:
+      case MPI3MR_BSG_BUFTYPE_MPI_REQUEST:
+        dout_buffers_size += bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[i].buf_len;
+        break;
+      case MPI3MR_BSG_BUFTYPE_RAIDMGMT_RESP:
+      case MPI3MR_BSG_BUFTYPE_DATA_IN:
+      case MPI3MR_BSG_BUFTYPE_MPI_REPLY:
+      case MPI3MR_BSG_BUFTYPE_ERR_RESPONSE:
+        din_buffers_size += bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[i].buf_len;
+        break;
+      default:
+      return set_err(EINVAL, "mpi3mr_cmd: bad buff_type");
+    }
+  }
+
+  // allocate the memory for the request / response buffers
+  sgl_dout_base_ptr = (uint8_t *)malloc(dout_buffers_size);
+  if (!sgl_dout_base_ptr)
+    throw std::bad_alloc();
+
+  sgl_din_base_ptr = (uint8_t *)malloc(din_buffers_size);
+  if (!sgl_din_base_ptr)
+    throw std::bad_alloc();
+
+  memset(sgl_dout_base_ptr, 0, dout_buffers_size);
+  memset(sgl_din_base_ptr, 0xFF, din_buffers_size);
+
+  // populate the requests : MPI req
+  mpi_scsi_req = (struct mpi3_scsi_io_request *) (sgl_dout_base_ptr + dout_buffers_size - (sizeof(struct mpi3_scsi_io_request)-(4 * sizeof(MPI3_SGE_UNION))));
+  mpi_scsi_req->function = MPI3_FUNCTION_SCSI_IO;
+  mpi_scsi_req->dev_handle = (uint16_t)(m_diskhandle);
+  mpi_scsi_req->flags = dir_flag;
+  mpi_scsi_req->data_length = dataLen;
+  memcpy(mpi_scsi_req->cdb.cdb32, cdb, cdbLen);
+
+  io_hdr_v4.guard = 'Q';
+  io_hdr_v4.protocol = BSG_PROTOCOL_SCSI;
+  io_hdr_v4.subprotocol = BSG_SUB_PROTOCOL_SCSI_TRANSPORT;
+  io_hdr_v4.response = (uint64_t)sense_buffer;
+  io_hdr_v4.max_response_len = sizeof(sense_buffer);
+  io_hdr_v4.request = (uint64_t)bsg_req;
+  io_hdr_v4.request_len = (uint32_t) bsg_req_len;
+  io_hdr_v4.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
+  io_hdr_v4.din_xferp = (uint64_t) sgl_din_base_ptr;
+  io_hdr_v4.din_xfer_len = (uint32_t) din_buffers_size;
+  io_hdr_v4.dout_xferp = (uint64_t) sgl_dout_base_ptr;
+  io_hdr_v4.dout_xfer_len = (uint32_t) dout_buffers_size;
+
+  int r = ioctl(m_fd, SG_IO, &io_hdr_v4);
+  if (r < 0) {
+    lib_printf("IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
+    free(sgl_dout_base_ptr);
+    free(sgl_din_base_ptr);
+    free(bsg_req);
+    return set_err(errno, "IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
+  }
+
+  // copy the buffer
+  uint8_t *buff = (uint8_t *)(sgl_din_base_ptr + sizeof(SL8_MPI_REPLY_BUF) + sizeof(MPI3_SCSI_IO_REPLY));
+  memcpy(data, buff, dataLen);
+
+  // free memory
+  free(sgl_dout_base_ptr);
+  free(sgl_din_base_ptr);
+  free(bsg_req);
+
+  return true;
+}
+
+bool linux_mpi3mr_device::scsi_pass_through(scsi_cmnd_io *iop)
+{
+  int report = scsi_debugmode;
+
+  if (report > 0) {
+    int k, j;
+    const unsigned char * ucp = iop->cmnd;
+    const char * np;
+    char buff[256];
+    const int sz = (int)sizeof(buff);
+
+    np = scsi_get_opcode_name(ucp);
+    j = snprintf(buff, sz, " [%s: ", np ? np : "<unknown opcode>");
+    for (k = 0; k < (int)iop->cmnd_len; ++k)
+      j += snprintf(&buff[j], (sz > j ? (sz - j) : 0), "%02x ", ucp[k]);
+    if ((report > 1) &&
+      (DXFER_TO_DEVICE == iop->dxfer_dir) && (iop->dxferp)) {
+      int trunc = (iop->dxfer_len > 256) ? 1 : 0;
+
+      snprintf(&buff[j], (sz > j ? (sz - j) : 0), "]\n  Outgoing "
+           "data, len=%d%s:\n", (int)iop->dxfer_len,
+           (trunc ? " [only first 256 bytes shown]" : ""));
+      dStrHex(iop->dxferp, (trunc ? 256 : iop->dxfer_len) , 1);
+    }
+    else
+      snprintf(&buff[j], (sz > j ? (sz - j) : 0), "]\n");
+    lib_printf("%s", buff);
+  }
+
+  // Controller rejects Test Unit Ready
+  if (iop->cmnd[0] == 0x00)
+  return true;
+
+  if (iop->cmnd[0] == SAT_ATA_PASSTHROUGH_12 || iop->cmnd[0] == SAT_ATA_PASSTHROUGH_16) {
+  // Controller does not return ATA output registers in SAT sense data
+  if (iop->cmnd[2] & (1 << 5)) // chk_cond
+    return set_err(ENOSYS, "ATA return descriptor not supported by controller firmware");
+  }
+  // SMART WRITE LOG SECTOR causing media errors
+  if ((iop->cmnd[0] == SAT_ATA_PASSTHROUGH_16 // SAT16 WRITE LOG
+    && iop->cmnd[14] == ATA_SMART_CMD && iop->cmnd[3]==0 && iop->cmnd[4] == ATA_SMART_WRITE_LOG_SECTOR) ||
+    (iop->cmnd[0] == SAT_ATA_PASSTHROUGH_12 // SAT12 WRITE LOG
+     && iop->cmnd[9] == ATA_SMART_CMD && iop->cmnd[3] == ATA_SMART_WRITE_LOG_SECTOR))
+  {
+  if(!failuretest_permissive)
+     return set_err(ENOSYS, "SMART WRITE LOG SECTOR may cause problems, try with -T permissive to force");
+  }
+  return mpi3mr_cmd(iop->cmnd_len, iop->cmnd,
+  iop->dxfer_len, iop->dxferp,
+  iop->max_sense_len, iop->sensep, report, iop->dxfer_dir);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2849,6 +3311,10 @@ private:
   int megasas_dcmd_cmd(int bus_no, uint32_t opcode, void *buf,
     size_t bufsize, uint8_t *mbox, size_t mboxlen, uint8_t *statusp);
   int megasas_pd_add_list(int bus_no, smart_device_list & devlist);
+
+  bool get_dev_mpi3mr(smart_device_list & devlist);
+  int mpi3mr_pd_add_list(int bus_no, smart_device_list & devlist);
+
   bool get_dev_sssraid(smart_device_list & devlist);
   int sssraid_pd_add_list(int bus_no, smart_device_list & devlist);
   int sssraid_pdlist_cmd(int bus_no, uint16_t start_idx, void *buf, size_t bufsize, uint8_t *statusp);
@@ -2985,6 +3451,39 @@ void linux_smart_interface::get_dev_list(smart_device_list & devlist,
   globfree(&globbuf);
 }
 
+bool linux_smart_interface::get_dev_mpi3mr(smart_device_list & devlist)
+{
+  // getting bus numbers with megaraid devices
+  // we are using sysfs to get list of all scsi hosts
+  DIR * dp = opendir ("/sys/class/scsi_host/");
+  char line[128];
+  FILE * fp = NULL;
+  if (dp != NULL)
+  {
+    struct dirent *ep;
+    while ((ep = readdir (dp)) != NULL) {
+      unsigned int host_no = 0;
+      if (!sscanf(ep->d_name, "host%u", &host_no))
+        continue;
+      /* proc_name should be mpi3mr */
+      char sysfsdir[256] = {0};
+      snprintf(sysfsdir, sizeof(sysfsdir) - 1,
+        "/sys/class/scsi_host/host%u/proc_name", host_no);
+      if((fp = fopen(sysfsdir, "r")) == NULL)
+        continue;
+      if(fgets(line, sizeof(line), fp) != NULL && !strncmp(line,"mpi3mr",6)) {
+          mpi3mr_pd_add_list(host_no, devlist);
+      }
+      fclose(fp);
+    }
+    (void) closedir (dp);
+  } else {
+    /* sysfs not mounted */
+    return false;
+  }
+  return true;
+}
+
 // getting devices from LSI SAS MegaRaid, if available
 bool linux_smart_interface::get_dev_megasas(smart_device_list & devlist)
 {
@@ -3084,7 +3583,7 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
     return set_err(EINVAL, "DEVICESCAN with pattern not implemented yet");
 
   // Scan type list
-  bool by_id = false, scan_megaraid = false, scan_sssraid = false;
+  bool by_id = false, scan_megaraid = false, scan_sssraid = false, scan_mpi3mr = false;
   const char * type_ata = nullptr, * type_scsi = nullptr, * type_sat = nullptr;
   const char * type_nvme = nullptr;
   for (unsigned i = 0; i < types.size(); i++) {
@@ -3101,21 +3600,23 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
       type_nvme = "nvme";
     else if (!strcmp(type, "megaraid"))
       scan_megaraid = true;
+    else if (!strcmp(type, "mpi3mr"))
+      scan_mpi3mr = true;
     else if (!strcmp(type, "sssraid"))
       scan_sssraid = true;
     else
       return set_err(EINVAL,
                      "Invalid type '%s', valid arguments are:"
-                     " by-id, ata, scsi, sat, nvme, megaraid, sssraid",
+                     " by-id, ata, scsi, sat, nvme, megaraid, mpi3mr, sssraid",
                      type);
   }
   // Use default if no type specified
-  if (!(type_ata || type_scsi || type_sat || type_nvme || scan_megaraid || scan_sssraid)) {
+  if (!(type_ata || type_scsi || type_sat || type_nvme || scan_megaraid || scan_mpi3mr || scan_sssraid)) {
      type_ata = type_scsi = type_sat = "";
 #ifdef WITH_NVME_DEVICESCAN // TODO: Remove when NVMe support is no longer EXPERIMENTAL
      type_nvme = "";
 #endif
-     scan_megaraid = scan_sssraid = true;
+     scan_megaraid = scan_mpi3mr = scan_sssraid = true;
   }
 
   const char * type_scsi_sat = ((type_scsi && type_sat) ? "" // detect both
@@ -3141,6 +3642,8 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
 
   if (scan_megaraid)
     get_dev_megasas(devlist);
+  if (scan_mpi3mr)
+    get_dev_mpi3mr(devlist);
   if (scan_sssraid)
     get_dev_sssraid(devlist);
   return true;
@@ -3223,6 +3726,88 @@ linux_smart_interface::megasas_dcmd_cmd(int bus_no, uint32_t opcode, void *buf,
   }
   return (0);
 }
+
+int
+linux_smart_interface::mpi3mr_pd_add_list(int bus_no, smart_device_list & devlist)
+{
+  /*
+  * Keep fetching the list in a loop until we have a large enough
+  * buffer to hold the entire list.
+  */
+  struct mpi3mr_all_tgt_info * list = 0;
+  int mrioc_id = linux_mpi3mr_device::get_mrioc_id(bus_no);
+  int   fd;
+  char  fname[100] = {0};
+
+  if (mrioc_id < 0)
+    return (-1);
+
+  sprintf(fname, "/dev/bsg/mpi3mrctl%d", mrioc_id);
+  if ((fd = open(fname, O_RDWR)) < 0) {
+    lib_printf("Couldn't open %s. line %d, errno %d\n", fname, __LINE__, errno);
+    return (-errno);
+  }
+
+  for (unsigned list_size = 1024; ; ) {
+    list = reinterpret_cast<struct mpi3mr_all_tgt_info *>(realloc(list, list_size));
+    if (!list)  {
+      close(fd);
+      throw std::bad_alloc();
+    }
+    memset(list, 0, list_size);
+    if (linux_mpi3mr_device::mpi3mr_dev_list_cmd(mrioc_id, list, list_size, fd) < 0)    {
+    free(list);
+    close(fd);
+      return (-1);
+    }
+    size_t size = list->num_devices * sizeof(struct mpi3mr_device_map_info);
+    size += (sizeof(struct mpi3mr_all_tgt_info)-sizeof(struct mpi3mr_device_map_info));
+    if (size <= list_size)
+      break;
+    list_size = size;
+  }
+  close(fd);
+
+  // adding all SCSI devices
+  for (unsigned i = 0; i < list->num_devices; i++) {
+    char line[128];
+    snprintf(line, sizeof(line) - 1, "/dev/bus/%d", bus_no);
+    smart_device * dev = new linux_mpi3mr_device(this, line, list->dmi[i].perst_id);
+
+    if (dev->is_scsi()) {
+        uint8_t inq[4] = {0}; // get the first 4 bytes
+        uint8_t cdb[6] = {INQUIRY, 0x00, 0x00, 0x00, 0x04, 0x00};
+        uint8_t sense[32];
+        scsi_cmnd_io cmd = {};
+
+        // populate the command
+        cmd.cmnd = cdb;
+         cmd.cmnd_len = sizeof(cdb);
+        cmd.dxfer_dir = DXFER_FROM_DEVICE;
+        cmd.dxfer_len = sizeof(inq);
+        cmd.dxferp = inq;
+        cmd.sensep = sense;
+        cmd.max_sense_len = sizeof(sense);
+        cmd.timeout = SCSI_TIMEOUT_DEFAULT;
+
+        dev->open();
+        (dev->to_scsi())->scsi_pass_through(&cmd);
+        dev->close();
+
+        if (inq[0] != 0x0d) // skip the SES targets
+          devlist.push_back(dev);
+        else
+          delete dev;
+    } else {
+      // unexpected device found
+      delete dev;
+    }
+  }
+
+  free(list);
+  return (0);
+}
+
 
 int
 linux_smart_interface::megasas_pd_add_list(int bus_no, smart_device_list & devlist)
@@ -3595,6 +4180,11 @@ smart_device * linux_smart_interface::get_custom_smart_device(const char * name,
   // MegaRAID ?
   if (sscanf(type, "megaraid,%d", &disknum) == 1) {
     return new linux_megaraid_device(this, name, disknum);
+  }
+
+  // mpi3mr
+  if (sscanf(type, "mpi3mr,%d", &disknum) == 1) {
+    return new linux_mpi3mr_device(this, name, disknum);
   }
 
   // SSSRAID

--- a/lib/os_linux.cpp
+++ b/lib/os_linux.cpp
@@ -1417,7 +1417,6 @@ private:
   unsigned int m_hba;
   unsigned int m_diskhandle = (unsigned int)-1;
   unsigned int m_mrioc_id = (unsigned int)-1;
-  int m_fd;
 
   bool mpi3mr_cmd(int cdbLen, void *cdb, int dataLen,
     void *data, int senseLen,void *sense, int report, int dxfer_dir);
@@ -1429,7 +1428,7 @@ linux_mpi3mr_device::linux_mpi3mr_device(smart_interface *intf,
   : smart_device(intf, dev_name, "mpi3mr", "mpi3mr"),
   linux_smart_device(O_RDWR | O_NONBLOCK),
   m_disknum(tgt),
-  m_hba(-1), m_fd(-1)
+  m_hba(-1)
 {
   set_info().info_name = strprintf("%s [mpi3mr_disk_%02d]", dev_name, m_disknum);
   set_info().dev_type = strprintf("mpi3mr,%d", tgt);
@@ -1438,8 +1437,6 @@ linux_mpi3mr_device::linux_mpi3mr_device(smart_interface *intf,
 linux_mpi3mr_device::~linux_mpi3mr_device()
 {
   close();
-  if (m_fd >= 0)
-    ::close(m_fd);
 }
 
 smart_device * linux_mpi3mr_device::autodetect_open()
@@ -1468,6 +1465,12 @@ smart_device * linux_mpi3mr_device::autodetect_open()
   if (len < 36)
       return this;
 
+  if (!memcmp(req_buff + 8, "DELL", 4)) {
+    if (report)
+      lib_printf("Got MPI3MR inquiry.. %s\n", req_buff+8);
+    return this;
+  }
+
   if (report)
     lib_printf("Got MPI3MR inquiry.. %s\n", req_buff+8);
 
@@ -1488,110 +1491,101 @@ bool linux_mpi3mr_device::open()
   int report = scsi_debugmode;
   char  mpi3_fname[128] = {0};
   bool  mpi3mr_found = false;
-  FILE * fp = NULL;
 
-  if (sscanf(get_dev_name(), "/dev/bus/%u", &m_hba) == 0) {
-  if (!linux_smart_device::open())
-    return false;
-  /* Get device HBA */
-  struct sg_scsi_id sgid;
-  if (ioctl(get_fd(), SG_GET_SCSI_ID, &sgid) == 0) {
-    m_hba = sgid.host_no;
-  }
-  else if (ioctl(get_fd(), SCSI_IOCTL_GET_BUS_NUMBER, &m_hba) != 0) {
-    int err = errno;
+  if (sscanf(get_dev_name(), "/dev/bus/%u", &m_hba) != 1) {
+    if (!linux_smart_device::open())
+      return false;
+    /* Get device HBA */
+    struct sg_scsi_id sgid;
+    if (ioctl(get_fd(), SG_GET_SCSI_ID, &sgid) == 0) {
+      m_hba = sgid.host_no;
+    }
+    else if (ioctl(get_fd(), SCSI_IOCTL_GET_BUS_NUMBER, &m_hba) != 0) {
+      int err = errno;
+      linux_smart_device::close();
+      return set_err(err, "can't get bus number");
+    } // we don't need this device anymore
     linux_smart_device::close();
-    return set_err(err, "can't get bus number");
-  } // we don't need this device anymore
-  linux_smart_device::close();
   }
 
   // check if the bus-number corresponds to mpi3mr driver
   char sysfsfile[128] = {0};
   snprintf(sysfsfile, sizeof(sysfsfile) - 1,
   "/sys/class/scsi_host/host%u/proc_name", m_hba);
-  if((fp = fopen(sysfsfile, "r")) != NULL) {
-  char line[128] = {0};
-  // check if it is using mpi3mr
-  if(fgets(line, sizeof(line), fp) != NULL && !strncmp(line,"mpi3mr",6))
-    mpi3mr_found = true;
-  fclose(fp);
+  stdio_file fp(sysfsfile, "r");
+  if(fp) {
+    char line[128] = {0};
+    // check if it is using mpi3mr
+    if (fgets(line, sizeof(line), fp) && !strncmp(line,"mpi3mr",6))
+      mpi3mr_found = true;
   } else {
-    if(report > 0)
-    lib_printf("cannot open %s, err %d\n",sysfsfile, errno);
+    if (report > 0)
+      lib_printf("cannot open %s, err %d\n", sysfsfile, errno);
   }
 
   if (mpi3mr_found == true) {
-  m_mrioc_id = get_mrioc_id(m_hba);
-  sprintf(mpi3_fname, "/dev/bsg/mpi3mrctl%d", m_mrioc_id);
-  if ((m_fd = ::open(mpi3_fname, O_RDWR)) >= 0) {
-    set_fd(m_fd);
+    m_mrioc_id = get_mrioc_id(m_hba);
+    snprintf(mpi3_fname, sizeof(mpi3_fname), "/dev/bsg/mpi3mrctl%d", m_mrioc_id);
+    int fd = ::open(mpi3_fname, O_RDWR);
+    if (fd >= 0) {
+      set_fd(fd);
+    }
+    else {
+      int err = errno;
+      return set_err(err, "cannot open %s", mpi3_fname);
+    }
   }
   else {
-    int err = errno;
-    return set_err(err, "cannot open %s", mpi3_fname);
-  }
-  }
-  else {
-  return set_err(false, "mpi3mr driver not related to bus %d", m_hba);
+    return set_err(false, "mpi3mr driver not related to bus %d", m_hba);
   }
 
   return true;
 }
 
-int
-linux_mpi3mr_device::get_mrioc_id(int bus_no)
+int linux_mpi3mr_device::get_mrioc_id(int bus_no)
 {
   int mrioc_id = -1;
   char sysfsfile[128] = {0};
   char line[64] = {0};
-  FILE * fp = NULL;
 
   snprintf(sysfsfile, sizeof(sysfsfile) - 1,
   "/sys/class/scsi_host/host%u/unique_id", bus_no);
-  if((fp = fopen(sysfsfile, "r")) == NULL)
+  stdio_file fp(sysfsfile, "r");
+  if (!fp)
     return (mrioc_id);
-  if(fgets(line, sizeof(line), fp) != NULL)
+  if (fgets(line, sizeof(line), fp))
     mrioc_id=atoi(line);
-  fclose(fp);
   return (mrioc_id);
 }
 
-int
-linux_mpi3mr_device::mpi3mr_dev_list_cmd(int mrioc_id, void *buf,
+int linux_mpi3mr_device::mpi3mr_dev_list_cmd(int mrioc_id, void *buf,
   size_t bufsize, int mpi3ctl_fd)
 {
-    struct mpi3mr_bsg_packet *bsg_req = NULL;
-    struct sg_io_v4 io_hdr_v4;
-    uint8_t sense_buffer[32] = { 0 };
-    uint32_t din_buffers_size = bufsize;
-    uint8_t *sgl_din_base_ptr = (uint8_t*)buf;
-    uint32_t bsg_req_len=0;
-
-    if (buf == NULL || bufsize == 0 || mpi3ctl_fd < 0)    {
+    if (!buf || bufsize == 0 || mpi3ctl_fd < 0) {
       errno = EINVAL;
       return (-errno);
     }
 
     // bsg_packet memory allocation
-    bsg_req_len = sizeof(struct mpi3mr_bsg_packet);
-    bsg_req = (struct mpi3mr_bsg_packet *)malloc(bsg_req_len);
-    if (!bsg_req)
-      throw std::bad_alloc();
+    std::unique_ptr<struct mpi3mr_bsg_packet> bsg_req(new struct mpi3mr_bsg_packet);
 
     bsg_req->cmd.drvrcmd.mrioc_id = mrioc_id;
     bsg_req->cmd.drvrcmd.opcode = MPI3MR_DRVBSG_OPCODE_ALLTGTDEVINFO;
     bsg_req->cmd_type = MPI3MR_DRV_CMD;
 
     // clean up the previous data
-    memset(&io_hdr_v4, 0,sizeof(io_hdr_v4));
+    uint8_t sense_buffer[32]{};
+    struct sg_io_v4 io_hdr_v4{};
+    uint32_t din_buffers_size = bufsize;
+    uint8_t *sgl_din_base_ptr = (uint8_t*)buf;
+
     io_hdr_v4.guard = 'Q';
     io_hdr_v4.protocol = BSG_PROTOCOL_SCSI;
     io_hdr_v4.subprotocol = BSG_SUB_PROTOCOL_SCSI_TRANSPORT;
     io_hdr_v4.response = (uint64_t)sense_buffer;
     io_hdr_v4.max_response_len = sizeof(sense_buffer);
     io_hdr_v4.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
-    io_hdr_v4.request = (uint64_t)bsg_req;
+    io_hdr_v4.request = (uint64_t)bsg_req.get();
     io_hdr_v4.request_len = sizeof(struct mpi3mr_bsg_packet);
     io_hdr_v4.din_xferp = (uint64_t)sgl_din_base_ptr;
     io_hdr_v4.din_xfer_len = din_buffers_size;
@@ -1599,73 +1593,46 @@ linux_mpi3mr_device::mpi3mr_dev_list_cmd(int mrioc_id, void *buf,
     int r = ioctl(mpi3ctl_fd, SG_IO, &io_hdr_v4);
     if (r < 0) {
         lib_printf("IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
-        free(bsg_req);
         return (r);
     }
-
-    free(bsg_req);
 
     return (0);
 }
 
 bool linux_mpi3mr_device::close()
 {
-  if (m_fd >= 0)
-    ::close(m_fd);
-  m_fd = -1;
-  set_fd(m_fd);
-  return true;
+  return linux_smart_device::close();
 }
 
-unsigned int
-linux_mpi3mr_device::mpi3mr_get_devhandle(int mrioc_id, unsigned int disknum)
+unsigned int linux_mpi3mr_device::mpi3mr_get_devhandle(int mrioc_id, unsigned int disknum)
 {
   unsigned int devhandle = (unsigned int)-1;
-  uint32_t din_buffers_size=0x800;
-  uint8_t *sgl_din_base_ptr = NULL;
-  struct mpi3mr_all_tgt_info *drv_all_tgt_info = NULL;
 
   /* get the devices from the driver to map the devh */
-  sgl_din_base_ptr = (uint8_t *)malloc(din_buffers_size);
-  if (!sgl_din_base_ptr)
-    throw std::bad_alloc();
+  uint32_t din_buffers_size = 0x800;
+  std::vector<uint8_t> sgl_din_base_ptr(din_buffers_size);
 
-  if (mpi3mr_dev_list_cmd(mrioc_id, sgl_din_base_ptr, din_buffers_size, m_fd) < 0)    {
-  free(sgl_din_base_ptr);
-  return (devhandle);
+  if (mpi3mr_dev_list_cmd(mrioc_id, sgl_din_base_ptr.data(), din_buffers_size, get_fd()) < 0) {
+    return (devhandle);
   }
 
   // process the response
-  drv_all_tgt_info = (struct mpi3mr_all_tgt_info *)sgl_din_base_ptr;
+  struct mpi3mr_all_tgt_info *drv_all_tgt_info = (struct mpi3mr_all_tgt_info *)sgl_din_base_ptr.data();
   for (int j = 0; j < drv_all_tgt_info->num_devices; j++) {
-    if(disknum == drv_all_tgt_info->dmi[j].perst_id) {
+    if (disknum == drv_all_tgt_info->dmi[j].perst_id) {
       devhandle = drv_all_tgt_info->dmi[j].handle;
       break;
     }
   }
 
-  free(sgl_din_base_ptr);
-
   return (devhandle);
 }
 
 /* Issue passthrough scsi commands to MR8 controllers */
-bool
-linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
+bool linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
   int dataLen, void *data,
   int /*senseLen*/, void * /*sense*/, int /*report*/, int dxfer_dir)
 {
-  struct mpi3mr_bsg_packet *bsg_req = NULL;
-  struct sg_io_v4 io_hdr_v4;
-  uint8_t sense_buffer[32] = { 0 };
-  uint32_t dout_buffers_size=0, din_buffers_size=0;
-  uint8_t *sgl_din_base_ptr = NULL, *sgl_dout_base_ptr = NULL;
-  uint32_t bsg_buf_entry_list_size=0, bsg_req_len=0;
-  uint32_t i = 0, dir_flag = 0;
-  struct mpi3_scsi_io_request *mpi_scsi_req = NULL;
-  uint8_t in_buf = 2; // 1 MPI Resp + DATA_IN
-  uint8_t out_buf = 2; // 1 MPI Req + DATA_OUT
-
   // get the mrioc_id for the bus, if not already known
   if (m_mrioc_id == (unsigned int)-1) {
     m_mrioc_id = get_mrioc_id(m_hba);
@@ -1682,6 +1649,8 @@ linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
     }
   }
 
+  uint32_t dir_flag = 0;
+  uint32_t dout_buffers_size = 0, din_buffers_size = 0;
   switch (dxfer_dir) {
     case DXFER_FROM_DEVICE:
       din_buffers_size = dataLen;
@@ -1698,12 +1667,13 @@ linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
       return set_err(EINVAL, "mpi3mr_cmd: bad dxfer_dir");
   }
 
-  bsg_buf_entry_list_size = sizeof(struct mpi3mr_buf_entry_list) + (sizeof(struct mpi3mr_buf_entry) * ((in_buf+out_buf)-1));
+  uint8_t in_buf = 2; // 1 MPI Resp + DATA_IN
+  uint8_t out_buf = 2; // 1 MPI Req + DATA_OUT
+  uint32_t bsg_buf_entry_list_size = sizeof(struct mpi3mr_buf_entry_list) + (sizeof(struct mpi3mr_buf_entry) * ((in_buf+out_buf)-1));
 
-  bsg_req_len = sizeof(struct mpi3mr_bsg_packet) + bsg_buf_entry_list_size;
-  bsg_req = (struct mpi3mr_bsg_packet *)malloc(bsg_req_len);
-  if (!bsg_req)
-    throw std::bad_alloc();
+  uint32_t bsg_req_len = sizeof(struct mpi3mr_bsg_packet) + bsg_buf_entry_list_size;
+  std::unique_ptr<uint8_t[]> bsg_req_buffer(new uint8_t[bsg_req_len]{});
+  struct mpi3mr_bsg_packet *bsg_req = (struct mpi3mr_bsg_packet *)bsg_req_buffer.get();
 
   bsg_req->cmd.mptcmd.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
   bsg_req->cmd_type = MPI3MR_MPT_CMD;
@@ -1720,7 +1690,7 @@ linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
   bsg_req->cmd.mptcmd.buf_entry_list.num_of_entries = (in_buf+out_buf);
 
   // get the total buffer size and allocate the memory
-  for(i = 0, dout_buffers_size = 0, din_buffers_size = 0; i < (in_buf+out_buf); i++) {
+  for(uint32_t i = 0; i < (in_buf+out_buf); i++) {
     switch (bsg_req->cmd.mptcmd.buf_entry_list.buf_entry[i].buf_type)   {
       case MPI3MR_BSG_BUFTYPE_RAIDMGMT_CMD:
       case MPI3MR_BSG_BUFTYPE_DATA_OUT:
@@ -1739,25 +1709,19 @@ linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
   }
 
   // allocate the memory for the request / response buffers
-  sgl_dout_base_ptr = (uint8_t *)malloc(dout_buffers_size);
-  if (!sgl_dout_base_ptr)
-    throw std::bad_alloc();
-
-  sgl_din_base_ptr = (uint8_t *)malloc(din_buffers_size);
-  if (!sgl_din_base_ptr)
-    throw std::bad_alloc();
-
-  memset(sgl_dout_base_ptr, 0, dout_buffers_size);
-  memset(sgl_din_base_ptr, 0xFF, din_buffers_size);
+  std::vector<uint8_t> sgl_dout_base_ptr(dout_buffers_size, 0);
+  std::vector<uint8_t> sgl_din_base_ptr(din_buffers_size, 0xFF);
 
   // populate the requests : MPI req
-  mpi_scsi_req = (struct mpi3_scsi_io_request *) (sgl_dout_base_ptr + dout_buffers_size - (sizeof(struct mpi3_scsi_io_request)-(4 * sizeof(MPI3_SGE_UNION))));
+  struct mpi3_scsi_io_request *mpi_scsi_req = (struct mpi3_scsi_io_request *) (sgl_dout_base_ptr.data() + dout_buffers_size - (sizeof(struct mpi3_scsi_io_request)-(4 * sizeof(MPI3_SGE_UNION))));
   mpi_scsi_req->function = MPI3_FUNCTION_SCSI_IO;
   mpi_scsi_req->dev_handle = (uint16_t)(m_diskhandle);
   mpi_scsi_req->flags = dir_flag;
   mpi_scsi_req->data_length = dataLen;
   memcpy(mpi_scsi_req->cdb.cdb32, cdb, cdbLen);
 
+  uint8_t sense_buffer[32]{};
+  struct sg_io_v4 io_hdr_v4{};
   io_hdr_v4.guard = 'Q';
   io_hdr_v4.protocol = BSG_PROTOCOL_SCSI;
   io_hdr_v4.subprotocol = BSG_SUB_PROTOCOL_SCSI_TRANSPORT;
@@ -1766,28 +1730,20 @@ linux_mpi3mr_device::mpi3mr_cmd(int cdbLen, void *cdb,
   io_hdr_v4.request = (uint64_t)bsg_req;
   io_hdr_v4.request_len = (uint32_t) bsg_req_len;
   io_hdr_v4.timeout = MPI3MR_APP_DEFAULT_TIMEOUT;
-  io_hdr_v4.din_xferp = (uint64_t) sgl_din_base_ptr;
+  io_hdr_v4.din_xferp = (uint64_t) sgl_din_base_ptr.data();
   io_hdr_v4.din_xfer_len = (uint32_t) din_buffers_size;
-  io_hdr_v4.dout_xferp = (uint64_t) sgl_dout_base_ptr;
+  io_hdr_v4.dout_xferp = (uint64_t) sgl_dout_base_ptr.data();
   io_hdr_v4.dout_xfer_len = (uint32_t) dout_buffers_size;
 
-  int r = ioctl(m_fd, SG_IO, &io_hdr_v4);
+  int r = ioctl(get_fd(), SG_IO, &io_hdr_v4);
   if (r < 0) {
     lib_printf("IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
-    free(sgl_dout_base_ptr);
-    free(sgl_din_base_ptr);
-    free(bsg_req);
     return set_err(errno, "IOCTL failed. line %d, r %d, errno %d\n", __LINE__, r, errno);
   }
 
   // copy the buffer
-  uint8_t *buff = (uint8_t *)(sgl_din_base_ptr + sizeof(SL8_MPI_REPLY_BUF) + sizeof(MPI3_SCSI_IO_REPLY));
+  uint8_t *buff = (uint8_t *)(sgl_din_base_ptr.data() + sizeof(SL8_MPI_REPLY_BUF) + sizeof(MPI3_SCSI_IO_REPLY));
   memcpy(data, buff, dataLen);
-
-  // free memory
-  free(sgl_dout_base_ptr);
-  free(sgl_din_base_ptr);
-  free(bsg_req);
 
   return true;
 }
@@ -3457,11 +3413,10 @@ bool linux_smart_interface::get_dev_mpi3mr(smart_device_list & devlist)
   // we are using sysfs to get list of all scsi hosts
   DIR * dp = opendir ("/sys/class/scsi_host/");
   char line[128];
-  FILE * fp = NULL;
-  if (dp != NULL)
+  if (dp)
   {
     struct dirent *ep;
-    while ((ep = readdir (dp)) != NULL) {
+    while ((ep = readdir (dp))) {
       unsigned int host_no = 0;
       if (!sscanf(ep->d_name, "host%u", &host_no))
         continue;
@@ -3469,12 +3424,12 @@ bool linux_smart_interface::get_dev_mpi3mr(smart_device_list & devlist)
       char sysfsdir[256] = {0};
       snprintf(sysfsdir, sizeof(sysfsdir) - 1,
         "/sys/class/scsi_host/host%u/proc_name", host_no);
-      if((fp = fopen(sysfsdir, "r")) == NULL)
+      stdio_file fp(sysfsdir, "r");
+      if (!fp)
         continue;
-      if(fgets(line, sizeof(line), fp) != NULL && !strncmp(line,"mpi3mr",6)) {
+      if (fgets(line, sizeof(line), fp) && !strncmp(line,"mpi3mr",6)) {
           mpi3mr_pd_add_list(host_no, devlist);
       }
-      fclose(fp);
     }
     (void) closedir (dp);
   } else {
@@ -3730,34 +3685,26 @@ linux_smart_interface::megasas_dcmd_cmd(int bus_no, uint32_t opcode, void *buf,
 int
 linux_smart_interface::mpi3mr_pd_add_list(int bus_no, smart_device_list & devlist)
 {
-  /*
-  * Keep fetching the list in a loop until we have a large enough
-  * buffer to hold the entire list.
-  */
-  struct mpi3mr_all_tgt_info * list = 0;
   int mrioc_id = linux_mpi3mr_device::get_mrioc_id(bus_no);
-  int   fd;
-  char  fname[100] = {0};
+  char  fname[100]{};
 
   if (mrioc_id < 0)
     return (-1);
 
-  sprintf(fname, "/dev/bsg/mpi3mrctl%d", mrioc_id);
-  if ((fd = open(fname, O_RDWR)) < 0) {
+  snprintf(fname, sizeof(fname) - 1, "/dev/bsg/mpi3mrctl%d", mrioc_id);
+  int fd = open(fname, O_RDWR);
+  if (fd < 0) {
     lib_printf("Couldn't open %s. line %d, errno %d\n", fname, __LINE__, errno);
     return (-errno);
   }
 
+  std::vector<uint8_t> list_buffer;
   for (unsigned list_size = 1024; ; ) {
-    list = reinterpret_cast<struct mpi3mr_all_tgt_info *>(realloc(list, list_size));
-    if (!list)  {
+    list_buffer.resize(list_size);
+    std::fill(list_buffer.begin(), list_buffer.end(), 0);
+    struct mpi3mr_all_tgt_info *list = (struct mpi3mr_all_tgt_info *)list_buffer.data();
+    if (linux_mpi3mr_device::mpi3mr_dev_list_cmd(mrioc_id, list, list_size, fd) < 0) {
       close(fd);
-      throw std::bad_alloc();
-    }
-    memset(list, 0, list_size);
-    if (linux_mpi3mr_device::mpi3mr_dev_list_cmd(mrioc_id, list, list_size, fd) < 0)    {
-    free(list);
-    close(fd);
       return (-1);
     }
     size_t size = list->num_devices * sizeof(struct mpi3mr_device_map_info);
@@ -3769,42 +3716,35 @@ linux_smart_interface::mpi3mr_pd_add_list(int bus_no, smart_device_list & devlis
   close(fd);
 
   // adding all SCSI devices
+  struct mpi3mr_all_tgt_info *list = (struct mpi3mr_all_tgt_info *)list_buffer.data();
   for (unsigned i = 0; i < list->num_devices; i++) {
     char line[128];
     snprintf(line, sizeof(line) - 1, "/dev/bus/%d", bus_no);
-    smart_device * dev = new linux_mpi3mr_device(this, line, list->dmi[i].perst_id);
+    std::unique_ptr<scsi_device> dev(new linux_mpi3mr_device(this, line, list->dmi[i].perst_id));
 
-    if (dev->is_scsi()) {
-        uint8_t inq[4] = {0}; // get the first 4 bytes
-        uint8_t cdb[6] = {INQUIRY, 0x00, 0x00, 0x00, 0x04, 0x00};
-        uint8_t sense[32];
-        scsi_cmnd_io cmd = {};
+    uint8_t inq[4]{};
+    uint8_t cdb[6] = {INQUIRY, 0x00, 0x00, 0x00, 0x04, 0x00};
+    uint8_t sense[32]{};
+    scsi_cmnd_io cmd{};
 
-        // populate the command
-        cmd.cmnd = cdb;
-         cmd.cmnd_len = sizeof(cdb);
-        cmd.dxfer_dir = DXFER_FROM_DEVICE;
-        cmd.dxfer_len = sizeof(inq);
-        cmd.dxferp = inq;
-        cmd.sensep = sense;
-        cmd.max_sense_len = sizeof(sense);
-        cmd.timeout = SCSI_TIMEOUT_DEFAULT;
+    // populate the command
+    cmd.cmnd = cdb;
+    cmd.cmnd_len = sizeof(cdb);
+    cmd.dxfer_dir = DXFER_FROM_DEVICE;
+    cmd.dxfer_len = sizeof(inq);
+    cmd.dxferp = inq;
+    cmd.sensep = sense;
+    cmd.max_sense_len = sizeof(sense);
+    cmd.timeout = SCSI_TIMEOUT_DEFAULT;
 
-        dev->open();
-        (dev->to_scsi())->scsi_pass_through(&cmd);
-        dev->close();
+    dev->open();
+    dev->scsi_pass_through(&cmd);
+    dev->close();
 
-        if (inq[0] != 0x0d) // skip the SES targets
-          devlist.push_back(dev);
-        else
-          delete dev;
-    } else {
-      // unexpected device found
-      delete dev;
-    }
+    if (inq[0] != 0x0d) // skip the SES targets
+      devlist.push_back(dev.release());
   }
 
-  free(list);
   return (0);
 }
 
@@ -4183,7 +4123,8 @@ smart_device * linux_smart_interface::get_custom_smart_device(const char * name,
   }
 
   // mpi3mr
-  if (sscanf(type, "mpi3mr,%d", &disknum) == 1) {
+  int n = -1;
+  if (sscanf(type, "mpi3mr,%d%n", &disknum, &n) == 1 && n == (int)strlen(type)) {
     return new linux_mpi3mr_device(this, name, disknum);
   }
 

--- a/lib/os_linux.cpp
+++ b/lib/os_linux.cpp
@@ -4124,8 +4124,7 @@ smart_device * linux_smart_interface::get_custom_smart_device(const char * name,
 
   // mpi3mr
   int n = -1;
-  size_t type_len = (type ? strlen(type) : 0);
-  if (sscanf(type, "mpi3mr,%d%n", &disknum, &n) == 1 && n == (int)type_len) {
+  if (type && sscanf(type, "mpi3mr,%d%n", &disknum, &n) == 1 && n == (int)strlen(type)) {
     return new linux_mpi3mr_device(this, name, disknum);
   }
 


### PR DESCRIPTION
https://github.com/smartmontools/smartmontools/pull/317

this pr adds support for Broadcom MPI3 RAID (MPI3MR) controllers.

- tested on multiple controller models of the type
- ATA/SCSI/NVMe functional, including autodetect type

### This implementation was developed with support and feedback from contributors who wish to remain anonymous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Complete MPI3MR RAID controller support for device monitoring and management
  * Automatic discovery and enumeration of MPI3MR devices from system buses
  * SCSI command passthrough capability for MPI3MR target access
  * New device type specification format for custom MPI3MR device selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->