### PR TITLE
drivedb.h: USB: Raspberry Pi USB Flash Drive (0x2e8a:0x0030)

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -7439,6 +7439,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // Raspberry Pi
+  { "USB: Raspberry Pi USB Flash Drive; ",
+    "0x2e8a:0x0030",
+    "",
+    "",
+    "-d sat,12"
+  },
   // 0x2eb9 (?): See Realtek (0x0bda) above
   // KIOXIA (?)
   { "USB: ; ", // KIOXIA EXCERIA PLUS


### PR DESCRIPTION
Add baseline autodetection for the above. Full SMART output:

```
$ sudo /usr/local/sbin/smartctl -x -a /dev/sda
smartctl pre-8.0-408 2026-04-12 [aarch64-linux-6.18.22-v8+] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     SU_BEMOMYRAB R
Serial Number:    4695600000015052
LU WWN Device Id: 0 000000 000000000
Firmware Version: D1.0.4C2
User Capacity:    513,315,700,224 bytes [513 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
TRIM Command:     Available
Device is:        Not in smartctl database 7.5/6122
ATA Version is:   ACS-2, ATA8-ACS T13/1699-D revision 4c
SATA Version is:  SATA 3.1, >6.0 Gb/s (4)
Local Time is:    Thu Apr 16 11:00:01 2026 BST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, NOT FROZEN [SEC1]

=== START OF READ SMART DATA SECTION ===
SMART Status command failed: scsi error unsupported scsi opcode
SMART overall-health self-assessment test result: PASSED
Warning: This result is based on an Attribute check.

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Total time to complete Offline
data collection:                (    0) seconds.
Offline data collection
capabilities:                    (0x00)         Offline data collection not supported.
SMART capabilities:            (0x0000) Automatic saving of SMART data                                  is not implemented.
Error logging capability:        (0x00) Error logging supported.
                                        General Purpose Logging supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     -O-R--   100   100   010    -    0
  5 Reallocated_Sector_Ct   -O-R--   100   100   010    -    0
  9 Power_On_Hours          -O-R--   100   100   010    -    0
 12 Power_Cycle_Count       -O-R--   100   100   010    -    200
160 Unknown_Attribute       -O-R--   100   100   010    -    0
161 Unknown_Attribute       -O-R--   100   100   010    -    8
163 Unknown_Attribute       -O-R--   100   100   010    -    0
164 Unknown_Attribute       -O-R--   100   100   010    -    363
165 Unknown_Attribute       -O-R--   100   100   010    -    2
166 Unknown_Attribute       -O-R--   100   100   010    -    0
167 Unknown_Attribute       -O-R--   100   100   010    -    0
168 Unknown_Attribute       -O-R--   100   100   010    -    0
169 Unknown_Attribute       -O-R--   100   100   010    -    100
181 Program_Fail_Cnt_Total  -O-R--   100   100   010    -    0
182 Erase_Fail_Count_Total  -O-R--   100   100   010    -    0
187 Reported_Uncorrect      -O-R--   100   100   010    -    0
192 Power-Off_Retract_Count -O-R--   100   100   010    -    0
194 Temperature_Celsius     -O-R--   100   100   010    -    51
196 Reallocated_Event_Count -O-R--   100   100   010    -    0
199 UDMA_CRC_Error_Count    -O-R--   100   100   010    -    0
241 Total_LBAs_Written      -O-R--   100   100   010    -    368
242 Total_LBAs_Read         -O-R--   100   100   010    -    36
245 Unknown_Attribute       -O-R--   100   100   010    -    0
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

Read SMART Log Directory failed: scsi error unsupported scsi opcode

ATA_READ_LOG_EXT (addr=0x00:0x00, page=0, n=1) failed: 48-bit ATA commands require SAT ATA PASS-THROUGH (16)
Read GP Log Directory failed

SMART Extended Comprehensive Error Log (GP Log 0x03) not supported

Read SMART Error Log failed: scsi error unsupported scsi opcode

SMART Extended Self-test Log (GP Log 0x07) not supported

Read SMART Self-test Log failed: scsi error unsupported scsi opcode

Selective Self-tests/Logging not supported

SCT Commands not supported

Device Statistics (GP/SMART Log 0x04) not supported

Pending Defects log (GP Log 0x0c) not supported

ATA_READ_LOG_EXT (addr=0x11:0x00, page=0, n=1) failed: 48-bit ATA commands require SAT ATA PASS-THROUGH (16)
Read SATA Phy Event Counters failed
```

Unknown fields will be subject to an update once we confirm the purpose with the vendor.