### PR TITLE
Add support for scanning "hidden" SCSI disks as sg devices (mptsas RAID PDs)

### DIFF
--- a/lib/os_linux.cpp
+++ b/lib/os_linux.cpp
@@ -2925,24 +2925,63 @@ void linux_smart_interface::get_dev_list(smart_device_list & devlist,
 
     // Find basename and detect device type
     static const regular_expression regex(
-    //     1 2              3 4                5                6
-      "^.*/((sd[a-z][a-z]?)|((nvme[0-9][0-9]?)(n[1-9][0-9]*)?)|(hd[a-z]))$"
+    //     1 2              3 4                5                6         7
+      "^.*/((sd[a-z][a-z]?)|((nvme[0-9][0-9]?)(n[1-9][0-9]*)?)|(hd[a-z])|(sg[0-9]+))$"
     );
-    constexpr int nmatch = 1 + 6;
+    constexpr int nmatch = 1 + 7;
     regular_expression::match_range match[nmatch];
     if (!regex.execute(chk_name, match)) {
       if (debug)
         lib_printf("%s, %s: device type ignored\n", name, chk_name);
       continue;
     }
-    int mi = 2; // 2 = sd*, 4 = nvme* (without namespace), 6 = hd*
+    int mi = 2; // 2 = sd*, 4 = nvme* (without namespace), 6 = hd*, 7 = sg*
     if (!(   match[mi].rm_so >= 0
           || match[mi+=2].rm_so >= 0
-          || match[mi+=2].rm_so >= 0))
+          || match[mi+=2].rm_so >= 0
+          || match[mi+=1].rm_so >= 0))
       continue; // Should not happen
 
-    // Skip if duplicate basename
+
     std::string key(chk_name + match[mi].rm_so, match[mi].rm_eo - match[mi].rm_so);
+
+    // Skip sg devices unless they are disks with no upper level driver bound.
+    // These are RAID physical disks on some drivers (e.g. mptsas/mpt3sas).
+    if (mi == 7) {
+      std::string devdir = "/sys/class/scsi_generic/" + key + "/device/";
+
+      stdio_file ftype((devdir + "type").c_str(), "r");
+      // Sysfs not mounted or path is not a SCSI device?
+      if (!ftype)
+        continue;
+
+      if (fgetc(ftype) != '0' || fgetc(ftype) != '\n') {
+        if (scsi_debugmode)
+          lib_printf("%s, %s: Ignoring: not a disk\n", name, key.c_str());
+        continue;
+      }
+
+      // Ignore as duplicate if the device has a driver attached
+      if (!access((devdir + "driver").c_str(), R_OK)) {
+        if (scsi_debugmode)
+          lib_printf("%s, %s: Ignoring: has an upper level driver (scan as disk)\n", name, key.c_str());
+        continue;
+      }
+
+      // Ignore "Universal Xport" devices, as they show up as disks but are
+      // masked out in the kernel (see drivers/scsi/scsi_devinfo.c)
+      stdio_file fmodel((devdir + "model").c_str(), "r");
+      if (fmodel) {
+        char model[256];
+        if (fgets(model, sizeof(model), fmodel) && !strncmp(model, "Universal Xport", 15)) {
+          if (scsi_debugmode)
+            lib_printf("%s, %s: Ignoring: Universal Xport device\n", name, key.c_str());
+          continue;
+        }
+      }
+    }
+
+    // Skip if duplicate basename
     if (devs_seen.count(key)) {
       if (debug)
         lib_printf("%s, %s: duplicate ignored\n", name, key.c_str());
@@ -2952,7 +2991,7 @@ void linux_smart_interface::get_dev_list(smart_device_list & devlist,
 
     // Allocate device object
     smart_device * dev;
-    if (mi == 2 && type_scsi_sat) {
+    if ((mi == 2 || mi == 7) && type_scsi_sat) {
       if (!*type_scsi_sat) { // scsi, sat, usb*, snt*
         dev = autodetect_smart_device(name);
         if (!dev) {
@@ -3084,7 +3123,7 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
     return set_err(EINVAL, "DEVICESCAN with pattern not implemented yet");
 
   // Scan type list
-  bool by_id = false, scan_megaraid = false, scan_sssraid = false;
+  bool by_id = false, scan_megaraid = false, scan_sssraid = false, scan_sg = false;
   const char * type_ata = nullptr, * type_scsi = nullptr, * type_sat = nullptr;
   const char * type_nvme = nullptr;
   for (unsigned i = 0; i < types.size(); i++) {
@@ -3103,10 +3142,12 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
       scan_megaraid = true;
     else if (!strcmp(type, "sssraid"))
       scan_sssraid = true;
+    else if (!strcmp(type, "sg"))
+      scan_sg = true;
     else
       return set_err(EINVAL,
                      "Invalid type '%s', valid arguments are:"
-                     " by-id, ata, scsi, sat, nvme, megaraid, sssraid",
+                     " by-id, ata, scsi, sat, sg, nvme, megaraid, sssraid",
                      type);
   }
   // Use default if no type specified
@@ -3132,6 +3173,14 @@ bool linux_smart_interface::scan_smart_devices(smart_device_list & devlist,
   if (type_scsi_sat) {
     get_dev_list(devlist, "/dev/sd[a-z]", false, devs_seen, type_scsi_sat, nullptr);
     get_dev_list(devlist, "/dev/sd[a-z][a-z]", false, devs_seen, type_scsi_sat, nullptr);
+  }
+
+  if (scan_sg) {
+    if (!type_scsi_sat)
+      type_scsi_sat = ""; // detect both
+    get_dev_list(devlist, "/dev/sg[0-9]", false, devs_seen, type_scsi_sat, nullptr);
+    get_dev_list(devlist, "/dev/sg[0-9][0-9]", false, devs_seen, type_scsi_sat, nullptr);
+    get_dev_list(devlist, "/dev/sg[0-9][0-9][0-9]", false, devs_seen, type_scsi_sat, nullptr);
   }
 
   if (type_nvme) {


### PR DESCRIPTION
Controllers using the mptsas/mpt3sas driver with RAID volumes will enumerate the RAID PDs as SCSI generic (sg) devices, without an associated SCSI disk (sd) device. These devices can already be accessed explicitly, they just aren't scanned.

Add support for scanning them by looking for sg devices which have a SCSI type of 0 (hard disk) and do not have any associated sd devices (to avoid duplication, since all sd devices have matching sg devices too).

Closes: #569

Tested on the following machines:

* Dell R320 with LSI SAS2208 based HBA (Dell H710 Mini flashed with LSI IR firmware) with 1 RAID1 volume and 2 JBOD disks:
  Correctly identifies the RAID physical disks, ignores the JBOD sg devices (those show up as sdX normally).

* Dell R410 with SAS1068E based HBA (Dell SAS 6/iR with stock IR firmware) with 1 RAID1 volume and 2 JBOD disks:
  Correctly identifies the RAID physical disks, ignores the JBOD sg devices (those show up as sdX normally).

* Dell R410 with SAS1068E as above, plus SAS2008 external controller (IT firmware) connected to a Dell MD1000 disk cage with JBOD disks:
  Correctly identifies the RAID physical disks, ignores the JBOD sg devices on both controllers (those show up as sdX normally).

* Dell R410 with SAS1068E based MegaRAID controller (PERC 6/i) with 2 RAID1 volumes:
  No change to existing behavior (all PDs detected via megaraid,N protocol).

(In case you're not familiar, LSI controllers like these behave as two completely different devices depending on firmware: either simpler HBAs with optional integrated-RAID support, or MegaRAID mode. MegaRAID is already supported by smartmontools using a dedicated protocol to find and access PDs, while this PR adds support for scanning PDs on the integrated-RAID support with HBA firmware.)

Tested with both smartctl and smartd. Sample smartctl output:

```
# ./src/smartctl --scan -r scsiioctl 
glob("/dev/hd[a-t]", .): error 3
glob("/dev/sd[a-z]", .): 4 entrie(s)
/dev/sda, sda: 'scsi' device added (requested type: '')
/dev/sdb, sdb: 'scsi' device added (requested type: '')
/dev/sdc, sdc: 'scsi' device added (requested type: '')
/dev/sdd, sdd: autodetection failed
glob("/dev/sd[a-z][a-z]", .): error 3
glob("/dev/sg[0-9]", .): 8 entrie(s)
sg0: Ignoring: has a scsi_disk device (duplicate)
sg1: Ignoring: has a scsi_disk device (duplicate)
/dev/sg2, sg2: 'scsi' device added (requested type: '')
sg3: Ignoring: has a scsi_disk device (duplicate)
/dev/sg4, sg4: 'scsi' device added (requested type: '')
sg5: Ignoring: not a disk
sg6: Ignoring: has a scsi_disk device (duplicate)
sg7: Ignoring: not a disk
glob("/dev/sg[0-9][0-9]", .): error 3
glob("/dev/sg[0-9][0-9][0-9]", .): error 3
glob("/dev/nvme[0-9]", .): 1 entrie(s)
/dev/nvme0, nvme0: 'nvme' device added (requested type: '')
glob("/dev/nvme[1-9][0-9]", .): error 3
/dev/sda -d scsi # /dev/sda, SCSI device
/dev/sdb -d scsi # /dev/sdb, SCSI device
/dev/sdc -d scsi # /dev/sdc, SCSI device
/dev/sg2 -d scsi # /dev/sg2, SCSI device
/dev/sg4 -d scsi # /dev/sg4, SCSI device
/dev/nvme0 -d nvme # /dev/nvme0, NVMe device
```

smartd:

```
# ./src/smartd -d -n 
smartd pre-8.0-418 2026-04-16 [x86_64-linux-6.14.11-4-pve] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

No configuration file /usr/local/etc/smartd.conf found, scanning devices
Device: /dev/sda, type changed from 'scsi' to 'sat'
Device: /dev/sda [SAT], opened
Device: /dev/sda [SAT], TOSHIBA MN08ADA800, S/N:<snip>, WWN:<snip>, FW:0601, 8.00 TB
Device: /dev/sda [SAT], not found in smartd database 7.5/6132.
Device: /dev/sda [SAT], is SMART capable. Adding to "monitor" list.
Device: /dev/sdb, opened
Device: /dev/sdb, [LSI      Logical Volume   3000], lu id: <snip>, S/N: <snip>, 145 GB
Device: /dev/sdb, IE (SMART) not enabled, skip device
Try 'smartctl -s on /dev/sdb' to turn on SMART features
Unable to register SCSI device /dev/sdb
Device: /dev/sdc, type changed from 'scsi' to 'sat'
Device: /dev/sdc [SAT], opened
Device: /dev/sdc [SAT], TOSHIBA MN08ADA800, S/N:<snip>, WWN:<snip>, FW:0601, 8.00 TB
Device: /dev/sdc [SAT], not found in smartd database 7.5/6132.
Device: /dev/sdc [SAT], is SMART capable. Adding to "monitor" list.
Device: /dev/sg2, opened
Device: /dev/sg2, [SEAGATE  ST3300657SS-H    EH02], lu id: <snip>, S/N: <snip>, 146 GB
Device: /dev/sg2, is SMART capable. Adding to "monitor" list.
Device: /dev/sg4, opened
Device: /dev/sg4, [SEAGATE  ST3300657SS-H    EH02], lu id: <snip>, S/N: <snip>, 146 GB
Device: /dev/sg4, is SMART capable. Adding to "monitor" list.
Device: /dev/nvme0, opened
Device: /dev/nvme0, Samsung SSD 970 EVO Plus 1TB, S/N:<snip>, FW:<snip>, 1.00 TB
Device: /dev/nvme0, is SMART capable. Adding to "monitor" list.
Monitoring 2 ATA/SATA, 2 SCSI/SAS and 1 NVMe devices
Device: /dev/sda [SAT], opened ATA device
Device: /dev/sda [SAT], previous self-test completed without error
Device: /dev/sdc [SAT], opened ATA device
Device: /dev/sdc [SAT], previous self-test completed without error
Device: /dev/sg2, opened SCSI device
Device: /dev/sg2, SMART health: passed
Device: /dev/sg4, opened SCSI device
Device: /dev/sg4, SMART health: passed
Device: /dev/nvme0, opened NVMe device
Device: /dev/nvme0, no self-test has ever been run
```

In all cases non-disk sg devices are also ignored (virtual/SATA CDROMs, the MD1000 enclosure SES controller, etc.).

