### PR TITLE
drivedb: update barracuda xt with "-v 188,raw16"

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -4851,10 +4851,12 @@ const drive_settings builtin_knowndrives[] = {
     "-v 188,raw16 -v 240,msec24hour32"
   },
   { "Seagate Barracuda XT", // tested with ST32000641AS/CC13,
-      // ST4000DX000-1C5160/CC42
+      // ST33000651AS/CC45, ST4000DX000-1C5160/CC42
     "ST(3(2000641|3000651)AS|4000DX000-.*)",
     "", "",
-    "-v 188,raw16" // tested with ST33000651AS/CC45
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 -v 188,raw16 "
+    "-v 195,raw24/raw32,ECC_On_the_Fly_Count "
+    "-v 240,msec24hour32"
   },
   { "Seagate Barracuda 7200.14 (AF)", // new firmware, tested with
       // ST3000DM001-9YN166/CC4H, ST3000DM001-9YN166/CC9E

--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -4853,7 +4853,8 @@ const drive_settings builtin_knowndrives[] = {
   { "Seagate Barracuda XT", // tested with ST32000641AS/CC13,
       // ST4000DX000-1C5160/CC42
     "ST(3(2000641|3000651)AS|4000DX000-.*)",
-    "", "", ""
+    "", "",
+    "-v 188,raw16" // tested with ST33000651AS/CC45
   },
   { "Seagate Barracuda 7200.14 (AF)", // new firmware, tested with
       // ST3000DM001-9YN166/CC4H, ST3000DM001-9YN166/CC9E


### PR DESCRIPTION
Value for attribute 188 being misinterpreted, resulting in abnormally high values being read. Update entry for Barracuda XT with "-v 188,raw16" to properly read it. Tested on my ST33000651AS/CC45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMART monitoring accuracy for Seagate Barracuda XT drives by adding recognition for an additional firmware revision and refining handling of several SMART attributes for more reliable readings and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->