### PR TITLE
drivedb.h: add Corsair Force LX SSD (mixed-case name ID)

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2489,6 +2489,7 @@ const drive_settings builtin_knowndrives[] = {
       // ADATA SU800/R0427A, ADATA SU800/R0918B, ADATA SU900/Q0125A, ADATA SU900/Q0710B
     "AMD R5SL512G|"// tested with AMD R5SL512G/V0929A0
     "CORSAIR FORCE LX SSD|" // tested with CORSAIR FORCE LX SSD/N0307A
+    "Corsair Force LX SSD|" // tested with Corsair Force LX SSD/N0307A
     "CHN (25SATA01M|mSATAM3) (060|128|256|512)|" // Zheino A1/M3 tested with CHN 25SATA01M 060/20150529,
       // CHN mSATAM3 128/Q1124A0,
     "CIS 2S M305 (16|32|64|128|256)GB|" // Ceroz M305, tested with CIS 2S M305 64GB/P0316B


### PR DESCRIPTION
I have a Corsair Force LX SSD, but the name ("Corsair Force LX SSD") doesn't match the related ID entry in drivedb.h, which is in all capital letters ("CORSAIR FORCE LX SSD").

Here's an excerpt of "smartctl" output using the existing released drivedb.h showing the SMART values as "unknown" for the drive:

```
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-7.0.8-custom-amd64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     Corsair Force LX SSD
Serial Number:    14456501000102180061
Firmware Version: N0307A
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
TRIM Command:     Available, deterministic, zeroed
Device is:        Not in smartctl database 7.3/6157
ATA Version is:   ACS-2 (minor revision not indicated)
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Sat May 30 11:28:15 2026 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Disabled
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, NOT FROZEN [SEC1]
Wt Cache Reorder: Unavailable

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever
                                        been run.
Total time to complete Offline
data collection:                (    0) seconds.
Offline data collection
capabilities:                    (0x71) SMART execute Offline immediate.
                                        No Auto Offline data collection support.
                                        Suspend Offline collection upon new
                                        command.
                                        No Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0002) Does not save SMART data before
                                        entering power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        (  10) minutes.
Conveyance self-test routine
recommended polling time:        (   2) minutes.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     ------   100   100   000    -    0
  5 Reallocated_Sector_Ct   ------   100   100   000    -    5
  9 Power_On_Hours          ------   100   100   000    -    137
 12 Power_Cycle_Count       ------   100   100   000    -    4188
192 Power-Off_Retract_Count ------   100   100   000    -    397
194 Temperature_Celsius     ------   100   100   000    -    33
195 Hardware_ECC_Recovered  ------   100   100   000    -    34051
196 Reallocated_Event_Count ------   100   100   016    -    7
199 UDMA_CRC_Error_Count    ------   100   100   050    -    22
160 Unknown_Attribute       ------   100   100   000    -    565
161 Unknown_Attribute       ------   100   100   000    -    37
163 Unknown_Attribute       ------   100   100   000    -    4
164 Unknown_Attribute       ------   100   100   000    -    102627
165 Unknown_Attribute       ------   100   100   000    -    157
166 Unknown_Attribute       ------   100   100   000    -    53
167 Unknown_Attribute       ------   100   100   000    -    101
241 Total_LBAs_Written      ------   100   100   000    -    296849
242 Total_LBAs_Read         ------   100   100   000    -    380360
168 Unknown_Attribute       ------   100   100   000    -    3000
169 Unknown_Attribute       ------   100   100   000    -    99
232 Available_Reservd_Space ------   100   100   000    -    88
175 Program_Fail_Count_Chip ------   100   100   000    -    0
176 Erase_Fail_Count_Chip   ------   100   100   000    -    0
177 Wear_Leveling_Count     ------   100   100   050    -    257
178 Used_Rsvd_Blk_Cnt_Chip  ------   100   100   000    -    5
181 Program_Fail_Cnt_Total  ------   100   100   000    -    0
182 Erase_Fail_Count_Total  ------   100   100   000    -    0
187 Reported_Uncorrect      ------   100   100   000    -    7
225 Unknown_SSD_Attribute   ------   100   100   000    -    296849
198 Offline_Uncorrectable   ------   100   100   000    -    4
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning
```

Here's an excerpt of the smartctl run output with the drivedb.h change included in this PR:

```
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-7.0.8-custom-amd64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Silicon Motion based SSDs
Device Model:     Corsair Force LX SSD
Serial Number:    14456501000102180061
Firmware Version: N0307A
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database
ATA Version is:   ACS-2 (minor revision not indicated)
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Sat May 30 11:49:59 2026 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Disabled
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, NOT FROZEN [SEC1]
Wt Cache Reorder: Unavailable

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever
                                        been run.
Total time to complete Offline
data collection:                (    0) seconds.
Offline data collection
capabilities:                    (0x71) SMART execute Offline immediate.
                                        No Auto Offline data collection support.
                                        Suspend Offline collection upon new
                                        command.
                                        No Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0002) Does not save SMART data before
                                        entering power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        (  10) minutes.
Conveyance self-test routine
recommended polling time:        (   2) minutes.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     ------   100   100   000    -    0
  5 Reallocated_Sector_Ct   ------   100   100   000    -    5
  9 Power_On_Hours          ------   100   100   000    -    137
 12 Power_Cycle_Count       ------   100   100   000    -    4188
192 Power-Off_Retract_Count ------   100   100   000    -    397
194 Temperature_Celsius     ------   100   100   000    -    33
195 Hardware_ECC_Recovered  ------   100   100   000    -    34051
196 Reallocated_Event_Count ------   100   100   016    -    7
199 UDMA_CRC_Error_Count    ------   100   100   050    -    22
160 Uncorrectable_Error_Cnt ------   100   100   000    -    565
161 Valid_Spare_Block_Cnt   ------   100   100   000    -    37
163 Initial_Bad_Block_Count ------   100   100   000    -    4
164 Total_Erase_Count       ------   100   100   000    -    102627
165 Max_Erase_Count         ------   100   100   000    -    157
166 Min_Erase_Count         ------   100   100   000    -    53
167 Average_Erase_Count     ------   100   100   000    -    101
241 Host_Writes_32MiB       ------   100   100   000    -    296849
242 Host_Reads_32MiB        ------   100   100   000    -    380360
168 Max_Erase_Count_of_Spec ------   100   100   000    -    3000
169 Remaining_Lifetime_Perc ------   100   100   000    -    99
232 Available_Reservd_Space ------   100   100   000    -    88
175 Program_Fail_Count_Chip ------   100   100   000    -    0
176 Erase_Fail_Count_Chip   ------   100   100   000    -    0
177 Wear_Leveling_Count     ------   100   100   050    -    257
178 Runtime_Invalid_Blk_Cnt ------   100   100   000    -    5
181 Program_Fail_Cnt_Total  ------   100   100   000    -    0
182 Erase_Fail_Count_Total  ------   100   100   000    -    0
187 Reported_Uncorrect      ------   100   100   000    -    7
225 Host_Writes_32MiB       ------   100   100   000    -    296849
198 Offline_Uncorrectable   ------   100   100   000    -    4
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning
```
I've verified that these values are correct (as much as possible) using the Corsair SSD Toolbox with this SSD.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced drive database to recognize additional Corsair Force LX SSD variants, improving hardware compatibility detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smartmontools/smartmontools/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->