### PR TITLE
src/smartd.cpp: print attrlog temperature for nvme, ata, scsi

### DIFF
--- a/src/smartd.cpp
+++ b/src/smartd.cpp
@@ -880,9 +880,6 @@ static void write_scsi_attrlog(FILE * f, const dev_state & state)
   if(state.scsi_nonmedium_error.found && state.scsi_nonmedium_error.nme.gotPC0) {
     fprintf(f, "\tnon-medium-errors;%" PRIu64 ";", state.scsi_nonmedium_error.nme.counterPC0);
   }
-  // write SCSI current temperature if it is monitored
-  if (state.temperature)
-    fprintf(f, "\ttemperature;%d;", state.temperature);
 }
 
 static void write_nvme_attrlog(FILE * f, const dev_state & state)
@@ -1153,6 +1150,10 @@ static bool write_dev_attrlog(const char * path, const dev_state & state)
     case 2: write_scsi_attrlog(f, state); break;
     case 3: write_nvme_attrlog(f, state); break;
   }
+
+  // write current temperature if it is monitored
+  if (state.temperature)
+    fprintf(f, "\ttemperature;%d;", state.temperature);
 
   fprintf(f, "\n");
   return true;


### PR DESCRIPTION
Restore printing temperature into attlog, as was before commit 565a4b7bf5e4d7b7a5de8abc59541d843cd661d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of temperature reporting in device attribute logs by ensuring the current temperature is logged via the shared attribute logging path (rather than the protocol-specific logging output).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->