### PR TITLE
drivedb.h: WD Blue / Red / Green SSDs: add new model numbers, general…

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -5518,10 +5518,15 @@ const drive_settings builtin_knowndrives[] = {
       // WDC  WDS500G2B0A-00SM50/401000WD,
       // WDC WDBNCE2500PNC/X61130WD, WDC WDBNCE0010PNC-WRSN/X41110WD,
       // WDC  WDS200T1R0A-68A4W0/411000WR, WDC  WDS400T1R0A-68A4W0/411000WR
+      //
+      // Untested names from data sheets:
+      // WDC WDS200T5G0A, WDC WDS100T5G0A, WDC WDS500G5G0A, WDC WDS250G5G0A,
+      // WDC WDS480G3G0B, WDC WDS240G3G0B (0A = 2.5', 0B= M.2)
     "WDC WDBNCE(250|500|00[124])0PNC(-.*)?|" // Blue 3D
-    "WDC  ?WDS((120|240|250|400|480|500)G|[124]00T)(1B|2B|1G|2G|[12]R)0[AB](-.*)?|"
+    "WDC  ?WDS((120|240|250|400|480|500)G|[124]00T)(1B|2B|[1235]G|[12]R)0[AB](-.*)?|"
       // *B* = Blue, *G* = Green, *2B* = Blue 3D NAND, *[12]R* = Red SA500
-    "WD (Green|(Blue|Red) SA5[01]0) (2\\.5|M\\.2 2280) ((25|50|100)0G|[24]T)B|" // tested with
+    "WD (Green|(Blue|Red) SA5[01]0) (2\\.5|M\\.2 2280) ((24|25|50|100)0G|[24]T)B|" // tested with
+      // WD Green 2.5 240GB/42077100 (printed label: WDS240G3G0A-00BJG0),
       // WD Green 2.5 1000GB/42077100,
       // WD Blue SA510 2.5 500GB/52046100, WD Blue SA510 2.5 1000GB/52008100,
       // WD Blue SA510 2.5 4TB/530309WD,  WD Blue SA510 M.2 2280 1000GB/52048100,


### PR DESCRIPTION
…ize regex

Add WDS200T5G0A, WDS100T5G0A, WDS500G5G0A, WDS250G5G0A, WDS480G3G0B, WDS240G3G0B, and "WD Green 2.5 240GB" (ticket #597). Generalize the capacity portion of both regexes to [0-9]{2,3}(G|T) / [0-9]{1,4}(G|T) so future capacities don't require regex changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of additional WD Blue/Red/Green SSD variants by recognizing more WDS model patterns, including more `...G...` capacity variants.
  * Expanded SA5xx SSD capacity matching to include an additional supported capacity option, along with updated detection examples for the SA5xx variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->