### PR TITLE
drivedb.h: Lenovo OEM Intel D3-S4510 Series SSDs

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2041,6 +2041,37 @@ const drive_settings builtin_knowndrives[] = {
     "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
     "-v 245,raw48,Percent_Life_Remaining"
   },
+  { "Lenovo OEM Intel D3-S4510 Series SSDs",
+    "^SSDSC2KB.*LEN$",
+    "^XCV1.*$",
+    "",
+    "-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 5,raw48,Reallocated_Sector_Ct "
+    "-v 9,raw48,Power_On_Hours "
+    "-v 12,raw48,Power_Cycle_Count "
+    /* High 24-bits: Soft/ECC error events; Low 24-bits: Total read activity units */
+    "-v 13,raw24/raw24,Soft_Errors_and_Reads "
+    "-v 100,raw48,Gigabytes_Erased "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    /* Slices 6 bytes into three 16-bit integers: Average, Maximum, and Minimum erase cycles */
+    "-v 173,raw16,Erase_Cycles_Avg_Max_Mn "
+    "-v 174,raw48,Unexpected_Power_Loss "
+    "-v 177,raw16,Wear_Delta_Avg_Max_Min "
+    "-v 184,raw48,End-to-End_Error "
+    "-v 187,raw48,Reported_Uncorrectable "
+    "-v 188,raw48,Command_Timeout "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 231,raw48,SATA_Phy_Error_Count "
+    "-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Media_Wearout_Indicator "
+    /* Slices 6 bytes into three 16-bit integers: Total tests, Minutes since last test, Duration (us) */
+    "-v 235,raw16,PLP_Tests_Min_Us "
+    "-v 237,raw16,PLP_Mirror_Tests_Min_Us "
+    "-v 241,raw48,Total_LBAs_Written "
+    "-v 242,raw48,Total_LBAs_Read"
+  },
   { "Kingston branded X25-V SSDs", // fixed firmware
     "KINGSTON SSDNow 40GB",
     "2CV102(J[89A-Z]|[K-Z].)", // >= "2CV102J8"

--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2041,15 +2041,15 @@ const drive_settings builtin_knowndrives[] = {
     "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
     "-v 245,raw48,Percent_Life_Remaining"
   },
-  { "Lenovo OEM Intel D3-S4510 Series SSDs",
+  { "Lenovo OEM Intel D3-S4510 Series SSDs", // tested with
     // SSDSC2KB038T8L       01PE328D7A09676LEN/XCV1LX42
     // SSDSC2KB038T8L       01PE328D7A09676LEN/XCV1LX46
     "SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)8L[ ]+[^ ]+LEN",
     "", "",
-    //"-v 1,raw48,Raw_Read_Error_Rate "
-    //"-v 5,raw48,Reallocated_Sector_Ct "
-    //"-v 9,raw48,Power_On_Hours "
-    //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw48,Reallocated_Sector_Ct "
+  //"-v 9,raw48,Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
     // High 24-bits: Soft/ECC error events; Low 24-bits: Total read activity units
     "-v 13,raw24/raw24,Soft_Errors_and_Reads "
     "-v 100,raw48,Gigabytes_Erased "
@@ -2062,11 +2062,18 @@ const drive_settings builtin_knowndrives[] = {
     "-v 177,raw16,Wear_Delta_Avg_Max_Min "
     "-v 184,raw48,End-to-End_Error_Count "
     "-v 187,raw48,Uncorrectable_Error_Cnt "
-    "-v 188,raw48,Command_Timeout "
+  //"-v 188,raw48,Command_Timeout "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
     "-v 192,raw48,Unsafe_Shutdown_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
     "-v 231,raw48,SATA_Phy_Error_Count "
-    //"-v 232,raw48,Available_Reservd_Space "
-    //"-v 233,raw48,Media_Wearout_Indicator "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
     // Slices 6 bytes into three 16-bit integers: Total tests, Minutes since last test, Duration (us)
     "-v 235,raw16,PLP_Tests_Min_Us "
     "-v 237,raw16,PLP_Mirror_Tests_Min_Us "

--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -2042,31 +2042,32 @@ const drive_settings builtin_knowndrives[] = {
     "-v 245,raw48,Percent_Life_Remaining"
   },
   { "Lenovo OEM Intel D3-S4510 Series SSDs",
-    "^SSDSC2KB.*LEN$",
-    "^XCV1.*$",
-    "",
-    "-v 1,raw48,Raw_Read_Error_Rate "
-    "-v 5,raw48,Reallocated_Sector_Ct "
-    "-v 9,raw48,Power_On_Hours "
-    "-v 12,raw48,Power_Cycle_Count "
-    /* High 24-bits: Soft/ECC error events; Low 24-bits: Total read activity units */
+    // SSDSC2KB038T8L       01PE328D7A09676LEN/XCV1LX42
+    // SSDSC2KB038T8L       01PE328D7A09676LEN/XCV1LX46
+    "SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)8L[ ]+[^ ]+LEN",
+    "", "",
+    //"-v 1,raw48,Raw_Read_Error_Rate "
+    //"-v 5,raw48,Reallocated_Sector_Ct "
+    //"-v 9,raw48,Power_On_Hours "
+    //"-v 12,raw48,Power_Cycle_Count "
+    // High 24-bits: Soft/ECC error events; Low 24-bits: Total read activity units
     "-v 13,raw24/raw24,Soft_Errors_and_Reads "
     "-v 100,raw48,Gigabytes_Erased "
     "-v 170,raw48,Available_Reservd_Space "
     "-v 171,raw48,Program_Fail_Count "
     "-v 172,raw48,Erase_Fail_Count "
-    /* Slices 6 bytes into three 16-bit integers: Average, Maximum, and Minimum erase cycles */
+    // Slices 6 bytes into three 16-bit integers: Average, Maximum, and Minimum erase cycles
     "-v 173,raw16,Erase_Cycles_Avg_Max_Mn "
-    "-v 174,raw48,Unexpected_Power_Loss "
+    "-v 174,raw48,Unsafe_Shutdown_Count "
     "-v 177,raw16,Wear_Delta_Avg_Max_Min "
-    "-v 184,raw48,End-to-End_Error "
-    "-v 187,raw48,Reported_Uncorrectable "
+    "-v 184,raw48,End-to-End_Error_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
     "-v 188,raw48,Command_Timeout "
     "-v 192,raw48,Unsafe_Shutdown_Count "
     "-v 231,raw48,SATA_Phy_Error_Count "
-    "-v 232,raw48,Available_Reservd_Space "
-    "-v 233,raw48,Media_Wearout_Indicator "
-    /* Slices 6 bytes into three 16-bit integers: Total tests, Minutes since last test, Duration (us) */
+    //"-v 232,raw48,Available_Reservd_Space "
+    //"-v 233,raw48,Media_Wearout_Indicator "
+    // Slices 6 bytes into three 16-bit integers: Total tests, Minutes since last test, Duration (us)
     "-v 235,raw16,PLP_Tests_Min_Us "
     "-v 237,raw16,PLP_Mirror_Tests_Min_Us "
     "-v 241,raw48,Total_LBAs_Written "


### PR DESCRIPTION
Add support for Lenovo OEM Intel D3-S4510 Series SSDs

Example output from device with firmware XCV1LX42:
```
# smartctl -x -a /dev/sdb
smartctl pre-8.0-467-modified 2026-07-01 [x86_64-linux-5.14.0-687.20.1.el9_8.x86_64] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Lenovo OEM Intel D3-S4510 Series SSDs
Device Model:     SSDSC2KB038T8L       01PE328D7A09676LEN
Serial Number:    PHYFXXXXXXXXXP8EGN
LU WWN Device Id: 5 5cd2e4 15375ad60
Firmware Version: XCV1LX42
User Capacity:    3,840,755,982,336 bytes [3.84 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database 7.5/6181
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Jul  8 18:11:27 2026 EEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x02)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(  576) seconds.
Offline data collection
capabilities: 			 (0x79) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   1) minutes.
Extended self-test routine
recommended polling time: 	 (   2) minutes.
Conveyance self-test routine
recommended polling time: 	 (   2) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     POSR--   130   130   039    -    4748
  5 Reallocated_Sector_Ct   PO--CK   100   100   001    -    4
  9 Power_On_Hours          -O--CK   100   100   000    -    13710
 12 Power_Cycle_Count       -O--CK   100   100   000    -    167
 13 Soft_Errors_and_Reads   -OSRC-   130   130   000    -    0/4748
100 Gigabytes_Erased        -O--CK   100   100   000    -    77718
170 Available_Reservd_Space PO--CK   099   099   010    -    25431
171 Program_Fail_Count      -O--CK   100   100   000    -    1
172 Erase_Fail_Count        -O--CK   100   100   000    -    0
173 Erase_Cycles_Avg_Max_Mn -O--CK   100   100   000    -    16 28 11
174 Unsafe_Shutdown_Count   -O--CK   100   100   000    -    67
177 Wear_Delta_Avg_Max_Min  -O--CK   040   040   000    -    16 28 11
184 End-to-End_Error_Count  PO--CK   100   100   090    -    0
187 Uncorrectable_Error_Cnt -O--CK   100   100   000    -    0
188 Command_Timeout         -O--CK   100   100   000    -    0
190 Airflow_Temperature_Cel -OS--K   066   066   029    -    34 (Min/Max 8/64)
192 Unsafe_Shutdown_Count   -O--CK   100   100   000    -    67
194 Temperature_Celsius     -O---K   100   100   000    -    34
195 Hardware_ECC_Recovered  -O-RC-   100   100   000    -    307192
196 Reallocated_Event_Count PO--CK   099   099   010    -    4
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
198 Offline_Uncorrectable   ----C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    -OSRCK   100   100   000    -    0
231 SATA_Phy_Error_Count    PO--CK   100   100   001    -    0
232 Available_Reservd_Space PO--CK   099   099   010    -    25431
233 Media_Wearout_Indicator -O--CK   100   100   000    -    0
235 PLP_Tests_Min_Us        PO--CK   100   100   010    -    167 65535 2295
237 PLP_Mirror_Tests_Min_Us -O--CK   100   100   000    -    167 65535 2295
241 Total_LBAs_Written      -O--CK   100   100   000    -    445032
242 Total_LBAs_Read         -O--CK   100   100   000    -    2796336
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O      8  Comprehensive SMART error log
0x03       GPL     R/O     20  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      2  Extended self-test log
0x08       GPL     R/O      2  Power Conditions log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x24       GPL     R/O    512  Current Device Internal Status Data log
0x25       GPL     R/O    512  Saved Device Internal Status Data log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xb0       GPL,SL  VS       1  Device vendor specific log
0xb8       GPL,SL  VS       1  Device vendor specific log
0xb9       GPL     VS    3336  Device vendor specific log
0xb9       SL      VS       8  Device vendor specific log
0xba       GPL     VS    1280  Device vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      8  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (20 sectors)
No Errors Logged

SMART Error Log Version: 1
No Errors Logged

SMART Extended Self-test Log Version: 1 (2 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     13700         -
# 2  Short offline       Completed without error       00%      4362         -
# 3  Short offline       Completed without error       00%      4194         -
# 4  Short offline       Completed without error       00%      4026         -
# 5  Short offline       Completed without error       00%      3858         -
# 6  Short offline       Completed without error       00%      3690         -
# 7  Short offline       Completed without error       00%      3522         -
# 8  Short offline       Completed without error       00%      3354         -
# 9  Short offline       Completed without error       00%      3186         -
#10  Short offline       Completed without error       00%      3018         -
#11  Short offline       Completed without error       00%      2850         -
#12  Short offline       Completed without error       00%      2682         -
#13  Short offline       Completed without error       00%      2514         -
#14  Short offline       Completed without error       00%      2346         -
#15  Short offline       Completed without error       00%      2178         -
#16  Short offline       Completed without error       00%      2010         -
#17  Short offline       Completed without error       00%      1842         -
#18  Short offline       Completed without error       00%      1674         -
#19  Short offline       Completed without error       00%      1506         -
#20  Short offline       Completed without error       00%      1338         -
#21  Short offline       Completed without error       00%      1170         -
#22  Short offline       Completed without error       00%      1012         -
#23  Short offline       Completed without error       00%       844         -
#24  Short offline       Completed without error       00%       676         -
#25  Short offline       Completed without error       00%       508         -

SMART Self-test log structure revision number 1
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     13700         -
# 2  Short offline       Completed without error       00%      4362         -
# 3  Short offline       Completed without error       00%      4194         -
# 4  Short offline       Completed without error       00%      4026         -
# 5  Short offline       Completed without error       00%      3858         -
# 6  Short offline       Completed without error       00%      3690         -
# 7  Short offline       Completed without error       00%      3522         -
# 8  Short offline       Completed without error       00%      3354         -
# 9  Short offline       Completed without error       00%      3186         -
#10  Short offline       Completed without error       00%      3018         -
#11  Short offline       Completed without error       00%      2850         -
#12  Short offline       Completed without error       00%      2682         -
#13  Short offline       Completed without error       00%      2514         -
#14  Short offline       Completed without error       00%      2346         -
#15  Short offline       Completed without error       00%      2178         -
#16  Short offline       Completed without error       00%      2010         -
#17  Short offline       Completed without error       00%      1842         -
#18  Short offline       Completed without error       00%      1674         -
#19  Short offline       Completed without error       00%      1506         -
#20  Short offline       Completed without error       00%      1338         -
#21  Short offline       Completed without error       00%      1170         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       1 (0x0001)
Device State:                        Active (0)
Current Temperature:                    34 Celsius
Power Cycle Min/Max Temperature:     24/34 Celsius
Lifetime    Min/Max Temperature:      8/64 Celsius
Specified Max Operating Temperature:    73 Celsius
Under/Over Temperature Limit Count:   0/0
Vendor specific:
00 00 2b 01 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      0/73 Celsius
Min/Max Temperature Limit:            0/73 Celsius
Temperature History Size (Index):    478 (308)

Index    Estimated Time   Temperature Celsius
 309    2026-07-08 10:14    34  ***************
 ...    ..( 14 skipped).    ..  ***************
 324    2026-07-08 10:29    34  ***************
 325    2026-07-08 10:30    33  **************
 326    2026-07-08 10:31    34  ***************
 327    2026-07-08 10:32    33  **************
 328    2026-07-08 10:33    33  **************
 329    2026-07-08 10:34    33  **************
 330    2026-07-08 10:35    34  ***************
 331    2026-07-08 10:36    34  ***************
 332    2026-07-08 10:37    34  ***************
 333    2026-07-08 10:38    33  **************
 334    2026-07-08 10:39    34  ***************
 ...    ..( 10 skipped).    ..  ***************
 345    2026-07-08 10:50    34  ***************
 346    2026-07-08 10:51    33  **************
 347    2026-07-08 10:52    33  **************
 348    2026-07-08 10:53    34  ***************
 ...    ..(  2 skipped).    ..  ***************
 351    2026-07-08 10:56    34  ***************
 352    2026-07-08 10:57     ?  -
 353    2026-07-08 10:58    34  ***************
 354    2026-07-08 10:59    33  **************
 355    2026-07-08 11:00    34  ***************
 ...    ..(  2 skipped).    ..  ***************
 358    2026-07-08 11:03    34  ***************
 359    2026-07-08 11:04     ?  -
 360    2026-07-08 11:05    36  *****************
 361    2026-07-08 11:06    35  ****************
 362    2026-07-08 11:07    34  ***************
 363    2026-07-08 11:08    35  ****************
 364    2026-07-08 11:09    34  ***************
 365    2026-07-08 11:10     ?  -
 366    2026-07-08 11:11    36  *****************
 367    2026-07-08 11:12    35  ****************
 ...    ..(  2 skipped).    ..  ****************
 370    2026-07-08 11:15    35  ****************
 371    2026-07-08 11:16    34  ***************
 372    2026-07-08 11:17     ?  -
 373    2026-07-08 11:18    36  *****************
 374    2026-07-08 11:19    35  ****************
 ...    ..(  3 skipped).    ..  ****************
 378    2026-07-08 11:23    35  ****************
 379    2026-07-08 11:24    34  ***************
 380    2026-07-08 11:25    34  ***************
 381    2026-07-08 11:26    35  ****************
 382    2026-07-08 11:27    35  ****************
 383    2026-07-08 11:28    35  ****************
 384    2026-07-08 11:29    34  ***************
 385    2026-07-08 11:30    35  ****************
 ...    ..(  2 skipped).    ..  ****************
 388    2026-07-08 11:33    35  ****************
 389    2026-07-08 11:34     ?  -
 390    2026-07-08 11:35    37  ******************
 391    2026-07-08 11:36    36  *****************
 392    2026-07-08 11:37    35  ****************
 ...    ..(  5 skipped).    ..  ****************
 398    2026-07-08 11:43    35  ****************
 399    2026-07-08 11:44    34  ***************
 ...    ..(  3 skipped).    ..  ***************
 403    2026-07-08 11:48    34  ***************
 404    2026-07-08 11:49    35  ****************
 405    2026-07-08 11:50    34  ***************
 406    2026-07-08 11:51    34  ***************
 407    2026-07-08 11:52    35  ****************
 408    2026-07-08 11:53    34  ***************
 ...    ..(  2 skipped).    ..  ***************
 411    2026-07-08 11:56    34  ***************
 412    2026-07-08 11:57     ?  -
 413    2026-07-08 11:58    30  ***********
 414    2026-07-08 11:59    30  ***********
 415    2026-07-08 12:00    31  ************
 416    2026-07-08 12:01    31  ************
 417    2026-07-08 12:02    31  ************
 418    2026-07-08 12:03    32  *************
 419    2026-07-08 12:04    32  *************
 420    2026-07-08 12:05    33  **************
 ...    ..(  8 skipped).    ..  **************
 429    2026-07-08 12:14    33  **************
 430    2026-07-08 12:15    34  ***************
 431    2026-07-08 12:16    33  **************
 432    2026-07-08 12:17    34  ***************
 433    2026-07-08 12:18    34  ***************
 434    2026-07-08 12:19    33  **************
 435    2026-07-08 12:20    34  ***************
 436    2026-07-08 12:21    33  **************
 437    2026-07-08 12:22    34  ***************
 ...    ..(172 skipped).    ..  ***************
 132    2026-07-08 15:15    34  ***************
 133    2026-07-08 15:16    35  ****************
 134    2026-07-08 15:17    34  ***************
 ...    ..( 43 skipped).    ..  ***************
 178    2026-07-08 16:01    34  ***************
 179    2026-07-08 16:02    35  ****************
 180    2026-07-08 16:03    34  ***************
 ...    ..( 15 skipped).    ..  ***************
 196    2026-07-08 16:19    34  ***************
 197    2026-07-08 16:20    35  ****************
 198    2026-07-08 16:21    34  ***************
 199    2026-07-08 16:22    34  ***************
 200    2026-07-08 16:23    35  ****************
 201    2026-07-08 16:24    34  ***************
 202    2026-07-08 16:25    35  ****************
 203    2026-07-08 16:26    34  ***************
 ...    ..( 37 skipped).    ..  ***************
 241    2026-07-08 17:04    34  ***************
 242    2026-07-08 17:05    35  ****************
 243    2026-07-08 17:06    34  ***************
 ...    ..( 12 skipped).    ..  ***************
 256    2026-07-08 17:19    34  ***************
 257    2026-07-08 17:20    35  ****************
 258    2026-07-08 17:21    34  ***************
 ...    ..( 12 skipped).    ..  ***************
 271    2026-07-08 17:34    34  ***************
 272    2026-07-08 17:35     ?  -
 273    2026-07-08 17:36    30  ***********
 274    2026-07-08 17:37    31  ************
 ...    ..(  2 skipped).    ..  ************
 277    2026-07-08 17:40    31  ************
 278    2026-07-08 17:41    32  *************
 279    2026-07-08 17:42    32  *************
 280    2026-07-08 17:43    32  *************
 281    2026-07-08 17:44    33  **************
 ...    ..(  7 skipped).    ..  **************
 289    2026-07-08 17:52    33  **************
 290    2026-07-08 17:53    34  ***************
 291    2026-07-08 17:54    34  ***************
 292    2026-07-08 17:55    33  **************
 293    2026-07-08 17:56    34  ***************
 ...    ..( 14 skipped).    ..  ***************
 308    2026-07-08 18:11    34  ***************

SCT Error Recovery Control:
           Read: Disabled
          Write: Disabled

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 2) ==
0x01  0x008  4             167  ---  Lifetime Power-On Resets
0x01  0x018  6     29165644238  ---  Logical Sectors Written [14.9 TB]
0x01  0x020  6       256185753  ---  Number of Write Commands
0x01  0x028  6    183260735283  ---  Logical Sectors Read [93.8 TB]
0x01  0x030  6      1056903235  ---  Number of Read Commands
0x01  0x038  6      2112490820  ---  Date and Time TimeStamp [586:48:10.820]
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               0  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              34  ---  Current Temperature
0x05  0x010  1              38  ---  Average Short Term Temperature
0x05  0x018  1              35  ---  Average Long Term Temperature
0x05  0x020  1              62  ---  Highest Temperature
0x05  0x028  1              14  ---  Lowest Temperature
0x05  0x030  1              40  ---  Highest Average Short Term Temperature
0x05  0x038  1              14  ---  Lowest Average Short Term Temperature
0x05  0x040  1              35  ---  Highest Average Long Term Temperature
0x05  0x048  1              15  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              73  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4             349  ---  Number of Hardware Resets
0x06  0x010  4             278  ---  Number of ASR Events
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  4            0  Command failed due to ICRC error
0x0002  4            0  R_ERR response for data FIS
0x0003  4            0  R_ERR response for device-to-host data FIS
0x0004  4            0  R_ERR response for host-to-device data FIS
0x0005  4            0  R_ERR response for non-data FIS
0x0006  4            0  R_ERR response for device-to-host non-data FIS
0x0007  4            0  R_ERR response for host-to-device non-data FIS
0x000a  4            2  Device-to-host register FISes sent due to a COMRESET
0x000b  4            0  CRC errors within host-to-device FIS
0x000d  4            0  Non-CRC errors within host-to-device FIS
```
Example output from device with firmware XCV1LX46
```
# src/smartctl -x -a /dev/sda
smartctl pre-8.0-467-modified 2026-07-01 [x86_64-linux-5.14.0-687.20.1.el9_8.x86_64] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Lenovo OEM Intel D3-S4510 Series SSDs
Device Model:     SSDSC2KB038T8L       01PE328D7A09676LEN
Serial Number:    PHYFXXXXXXXXXX8EGN
LU WWN Device Id: 5 5cd2e4 15375832b
Firmware Version: XCV1LX46
User Capacity:    3,840,755,982,336 bytes [3.84 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database 7.5/6181
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Jul  8 18:12:52 2026 EEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x02)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(  576) seconds.
Offline data collection
capabilities: 			 (0x79) SMART execute Offline immediate.
					No Auto Offline data collection support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   1) minutes.
Extended self-test routine
recommended polling time: 	 (   2) minutes.
Conveyance self-test routine
recommended polling time: 	 (   2) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     POSR--   130   130   039    -    4748
  5 Reallocated_Sector_Ct   PO--CK   100   100   001    -    0
  9 Power_On_Hours          -O--CK   100   100   000    -    26886
 12 Power_Cycle_Count       -O--CK   100   100   000    -    73
 13 Soft_Errors_and_Reads   -OSRC-   130   130   000    -    0/4748
100 Gigabytes_Erased        -O--CK   100   100   000    -    169259
170 Available_Reservd_Space PO--CK   100   100   010    -    25525
171 Program_Fail_Count      -O--CK   100   100   000    -    0
172 Erase_Fail_Count        -O--CK   100   100   000    -    0
173 Erase_Cycles_Avg_Max_Mn -O--CK   100   100   000    -    35 42 27
174 Unsafe_Shutdown_Count   -O--CK   100   100   000    -    63
177 Wear_Delta_Avg_Max_Min  -O--CK   065   065   000    -    35 42 27
184 End-to-End_Error_Count  PO--CK   100   100   090    -    0
187 Uncorrectable_Error_Cnt -O--CK   100   100   000    -    0
188 Command_Timeout         -O--CK   100   100   000    -    0
190 Airflow_Temperature_Cel -OS--K   067   067   029    -    33 (Min/Max 14/49)
192 Unsafe_Shutdown_Count   -O--CK   100   100   000    -    63
194 Temperature_Celsius     -O---K   100   100   000    -    33
195 Hardware_ECC_Recovered  -O-RC-   100   100   000    -    1325647
196 Reallocated_Event_Count PO--CK   100   100   010    -    0
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
198 Offline_Uncorrectable   ----C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    -OSRCK   100   100   000    -    0
231 SATA_Phy_Error_Count    PO--CK   100   100   001    -    0
232 Available_Reservd_Space PO--CK   100   100   010    -    25525
233 Media_Wearout_Indicator -O--CK   100   100   000    -    0
235 PLP_Tests_Min_Us        PO--CK   100   100   010    -    73 65535 2343
237 PLP_Mirror_Tests_Min_Us -O--CK   100   100   000    -    73 65535 2343
241 Total_LBAs_Written      -O--CK   100   100   000    -    1495275
242 Total_LBAs_Read         -O--CK   100   100   000    -    4177657
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O      8  Comprehensive SMART error log
0x03       GPL     R/O     20  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      2  Extended self-test log
0x08       GPL     R/O      2  Power Conditions log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x24       GPL     R/O    512  Current Device Internal Status Data log
0x25       GPL     R/O    512  Saved Device Internal Status Data log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xb0       GPL,SL  VS       1  Device vendor specific log
0xb8       GPL,SL  VS       1  Device vendor specific log
0xb9       GPL     VS    3336  Device vendor specific log
0xb9       SL      VS       8  Device vendor specific log
0xba       GPL     VS    1280  Device vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      8  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (20 sectors)
No Errors Logged

SMART Error Log Version: 1
No Errors Logged

SMART Extended Self-test Log Version: 1 (2 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     26875         -
# 2  Short offline       Completed without error       00%     19812         -
# 3  Short offline       Aborted by host               00%     19812         -
# 4  Short offline       Completed without error       00%     19657         -
# 5  Short offline       Completed without error       00%     19489         -
# 6  Short offline       Completed without error       00%     19321         -
# 7  Short offline       Completed without error       00%     19153         -
# 8  Short offline       Completed without error       00%     18985         -
# 9  Short offline       Completed without error       00%     18817         -
#10  Short offline       Completed without error       00%     18649         -
#11  Short offline       Completed without error       00%     18481         -
#12  Short offline       Completed without error       00%     18313         -
#13  Short offline       Completed without error       00%     18145         -
#14  Short offline       Completed without error       00%     17977         -
#15  Short offline       Completed without error       00%     17809         -
#16  Short offline       Completed without error       00%     17641         -
#17  Short offline       Completed without error       00%     17473         -
#18  Short offline       Completed without error       00%     17305         -
#19  Short offline       Completed without error       00%     17137         -
#20  Short offline       Completed without error       00%     16969         -
#21  Short offline       Completed without error       00%     16801         -
#22  Short offline       Completed without error       00%     16633         -
#23  Short offline       Completed without error       00%     16465         -
#24  Short offline       Completed without error       00%     16297         -
#25  Short offline       Completed without error       00%     16129         -

SMART Self-test log structure revision number 1
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     26875         -
# 2  Short offline       Completed without error       00%     19812         -
# 3  Short offline       Aborted by host               00%     19812         -
# 4  Short offline       Completed without error       00%     19657         -
# 5  Short offline       Completed without error       00%     19489         -
# 6  Short offline       Completed without error       00%     19321         -
# 7  Short offline       Completed without error       00%     19153         -
# 8  Short offline       Completed without error       00%     18985         -
# 9  Short offline       Completed without error       00%     18817         -
#10  Short offline       Completed without error       00%     18649         -
#11  Short offline       Completed without error       00%     18481         -
#12  Short offline       Completed without error       00%     18313         -
#13  Short offline       Completed without error       00%     18145         -
#14  Short offline       Completed without error       00%     17977         -
#15  Short offline       Completed without error       00%     17809         -
#16  Short offline       Completed without error       00%     17641         -
#17  Short offline       Completed without error       00%     17473         -
#18  Short offline       Completed without error       00%     17305         -
#19  Short offline       Completed without error       00%     17137         -
#20  Short offline       Completed without error       00%     16969         -
#21  Short offline       Completed without error       00%     16801         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       1 (0x0001)
Device State:                        Active (0)
Current Temperature:                    33 Celsius
Power Cycle Min/Max Temperature:     24/33 Celsius
Lifetime    Min/Max Temperature:     14/49 Celsius
Specified Max Operating Temperature:    73 Celsius
Under/Over Temperature Limit Count:   0/0
Vendor specific:
00 00 2b 01 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      0/73 Celsius
Min/Max Temperature Limit:            0/73 Celsius
Temperature History Size (Index):    478 (294)

Index    Estimated Time   Temperature Celsius
 295    2026-07-08 10:15    33  **************
 ...    ..( 40 skipped).    ..  **************
 336    2026-07-08 10:56    33  **************
 337    2026-07-08 10:57     ?  -
 338    2026-07-08 10:58    32  *************
 339    2026-07-08 10:59    32  *************
 340    2026-07-08 11:00    33  **************
 ...    ..(  2 skipped).    ..  **************
 343    2026-07-08 11:03    33  **************
 344    2026-07-08 11:04     ?  -
 345    2026-07-08 11:05    33  **************
 346    2026-07-08 11:06    34  ***************
 ...    ..(  2 skipped).    ..  ***************
 349    2026-07-08 11:09    34  ***************
 350    2026-07-08 11:10     ?  -
 351    2026-07-08 11:11    34  ***************
 ...    ..(  4 skipped).    ..  ***************
 356    2026-07-08 11:16    34  ***************
 357    2026-07-08 11:17     ?  -
 358    2026-07-08 11:18    34  ***************
 ...    ..( 11 skipped).    ..  ***************
 370    2026-07-08 11:30    34  ***************
 371    2026-07-08 11:31    35  ****************
 372    2026-07-08 11:32    35  ****************
 373    2026-07-08 11:33    35  ****************
 374    2026-07-08 11:34     ?  -
 375    2026-07-08 11:35    35  ****************
 376    2026-07-08 11:36    35  ****************
 377    2026-07-08 11:37    34  ***************
 ...    ..( 16 skipped).    ..  ***************
 394    2026-07-08 11:54    34  ***************
 395    2026-07-08 11:55    33  **************
 396    2026-07-08 11:56    33  **************
 397    2026-07-08 11:57     ?  -
 398    2026-07-08 11:58    28  *********
 399    2026-07-08 11:59    29  **********
 400    2026-07-08 12:00    30  ***********
 401    2026-07-08 12:01    30  ***********
 402    2026-07-08 12:02    31  ************
 403    2026-07-08 12:03    31  ************
 404    2026-07-08 12:04    31  ************
 405    2026-07-08 12:05    32  *************
 ...    ..(  5 skipped).    ..  *************
 411    2026-07-08 12:11    32  *************
 412    2026-07-08 12:12    33  **************
 ...    ..(125 skipped).    ..  **************
  60    2026-07-08 14:18    33  **************
  61    2026-07-08 14:19    34  ***************
  62    2026-07-08 14:20    34  ***************
  63    2026-07-08 14:21    33  **************
 ...    ..(166 skipped).    ..  **************
 230    2026-07-08 17:08    33  **************
 231    2026-07-08 17:09    34  ***************
 ...    ..( 24 skipped).    ..  ***************
 256    2026-07-08 17:34    34  ***************
 257    2026-07-08 17:35     ?  -
 258    2026-07-08 17:36    28  *********
 259    2026-07-08 17:37    29  **********
 260    2026-07-08 17:38    30  ***********
 261    2026-07-08 17:39    30  ***********
 262    2026-07-08 17:40    31  ************
 263    2026-07-08 17:41    31  ************
 264    2026-07-08 17:42    31  ************
 265    2026-07-08 17:43    32  *************
 ...    ..(  4 skipped).    ..  *************
 270    2026-07-08 17:48    32  *************
 271    2026-07-08 17:49    33  **************
 ...    ..( 22 skipped).    ..  **************
 294    2026-07-08 18:12    33  **************

SCT Error Recovery Control:
           Read: Disabled
          Write: Disabled

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 2) ==
0x01  0x008  4              73  ---  Lifetime Power-On Resets
0x01  0x018  6     97994370497  ---  Logical Sectors Written [50.1 TB]
0x01  0x020  6        93459489  ---  Number of Write Commands
0x01  0x028  6    273786991982  ---  Logical Sectors Read [140 TB]
0x01  0x030  6      6940927590  ---  Number of Read Commands
0x01  0x038  6      2300603234  ---  Date and Time TimeStamp [639:03:23.234]
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               0  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              33  ---  Current Temperature
0x05  0x010  1              34  ---  Average Short Term Temperature
0x05  0x018  1              24  ---  Average Long Term Temperature
0x05  0x020  1              48  ---  Highest Temperature
0x05  0x028  1              18  ---  Lowest Temperature
0x05  0x030  1              34  ---  Highest Average Short Term Temperature
0x05  0x038  1              21  ---  Lowest Average Short Term Temperature
0x05  0x040  1              30  ---  Highest Average Long Term Temperature
0x05  0x048  1              23  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              73  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4             132  ---  Number of Hardware Resets
0x06  0x010  4              77  ---  Number of ASR Events
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               0  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  4            0  Command failed due to ICRC error
0x0002  4            0  R_ERR response for data FIS
0x0003  4            0  R_ERR response for device-to-host data FIS
0x0004  4            0  R_ERR response for host-to-device data FIS
0x0005  4            0  R_ERR response for non-data FIS
0x0006  4            0  R_ERR response for device-to-host non-data FIS
0x0007  4            0  R_ERR response for host-to-device non-data FIS
0x000a  4            2  Device-to-host register FISes sent due to a COMRESET
0x000b  4            0  CRC errors within host-to-device FIS
0x000d  4            0  Non-CRC errors within host-to-device FIS
```

The check passes with both firmwares.
```
# smartctl -P show /dev/sda
smartctl pre-8.0-467-modified 2026-07-01 [x86_64-linux-5.14.0-687.20.1.el9_8.x86_64] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

Drive found in smartmontools Database.  Drive identity strings:
MODEL:              SSDSC2KB038T8L       01PE328D7A09676LEN
FIRMWARE:           XCV1LX46
match smartmontools Drive Database entry:
MODEL REGEXP:       SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)8L[ ]+[^ ]+LEN
FIRMWARE REGEXP:    .*
MODEL FAMILY:       Lenovo OEM Intel D3-S4510 Series SSDs
ATTRIBUTE OPTIONS:  013 Soft_Errors_and_Reads
                    100 Gigabytes_Erased
                    170 Available_Reservd_Space
                    171 Program_Fail_Count
                    172 Erase_Fail_Count
                    173 Erase_Cycles_Avg_Max_Mn
                    174 Unsafe_Shutdown_Count
                    177 Wear_Delta_Avg_Max_Min
                    184 End-to-End_Error_Count
                    187 Uncorrectable_Error_Cnt
                    188 Command_Timeout
                    192 Unsafe_Shutdown_Count
                    231 SATA_Phy_Error_Count
                    235 PLP_Tests_Min_Us
                    237 PLP_Mirror_Tests_Min_Us
                    241 Total_LBAs_Written
                    242 Total_LBAs_Read
# smartctl -P show /dev/sdb
smartctl pre-8.0-467-modified 2026-07-01 [x86_64-linux-5.14.0-687.20.1.el9_8.x86_64] (local build)
Copyright (C) 2002-26, Bruce Allen, Christian Franke, www.smartmontools.org

Drive found in smartmontools Database.  Drive identity strings:
MODEL:              SSDSC2KB038T8L       01PE328D7A09676LEN
FIRMWARE:           XCV1LX42
match smartmontools Drive Database entry:
MODEL REGEXP:       SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)8L[ ]+[^ ]+LEN
FIRMWARE REGEXP:    .*
MODEL FAMILY:       Lenovo OEM Intel D3-S4510 Series SSDs
ATTRIBUTE OPTIONS:  013 Soft_Errors_and_Reads
                    100 Gigabytes_Erased
                    170 Available_Reservd_Space
                    171 Program_Fail_Count
                    172 Erase_Fail_Count
                    173 Erase_Cycles_Avg_Max_Mn
                    174 Unsafe_Shutdown_Count
                    177 Wear_Delta_Avg_Max_Min
                    184 End-to-End_Error_Count
                    187 Uncorrectable_Error_Cnt
                    188 Command_Timeout
                    192 Unsafe_Shutdown_Count
                    231 SATA_Phy_Error_Count
                    235 PLP_Tests_Min_Us
                    237 PLP_Mirror_Tests_Min_Us
                    241 Total_LBAs_Written
                    242 Total_LBAs_Read
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for **Lenovo OEM Intel D3-S4510 Series SSDs**, improving drive detection and SMART attribute reporting.
* **Bug Fixes**
  * Expanded SMART attribute decoding and mappings so drive health and usage details display more accurately for supported models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->