### PR TITLE
`drivedb.h`: USB: JMicron JMS583 (0x152d:0x0583, -d sat)

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -7098,7 +7098,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "USB: ; JMicron",
     "0x152d:0x0583", // USB->SATA adapter using default id of JMS583 (see below)
-    "0x0414",
+    "0x(0414|3202)",
     "",
     "-d sat"
   },


### PR DESCRIPTION
Hello @chrfranke, cool to see Smartmontools on GitHub now!

I'd like to add the following device, so that `smartctl` no longer reports `USB bridge [0x152d:0x0583 (0x3202)] type is ambiguous: 'sat' or 'sntjmicron'` to the user. I bough the device at https://www.amazon.de/dp/B0FM4FFLBW , and it roughly looks like this:

<img width="987" height="978" alt="6130ccBW-6L _AC_SL1000_" src="https://github.com/user-attachments/assets/d7a94f38-eb47-43e9-9ba6-03498303f9a0" />

PS: I am *not* affiliated with "Sh." in any form.

### Before

```console
# sudo update-smart-drivedb --force --no-verify --file "$PWD"/drivedb/drivedb.h
/var/db/smartmontools/drivedb.h ?/? replaced with ?/? (NOT VERIFIED)

# sudo smartctl --info /dev/sda
[..]
/dev/sda: USB bridge [0x152d:0x0583 (0x3202)] type is ambiguous: 'sat' or 'sntjmicron'
Please specify device type with the -d option.
[..]

# lsusb
[..]
Bus 004 Device 009: ID 152d:0583 JMicron Technology Corp. / JMicron USA Technology Corp. JMS583Gen 2 to PCIe Gen3x2 Bridge
```

(Note the lack of space before "Gen 2" and also the "Gen3x2" :shrug:)

### After
```console
# sudo smartctl --info /dev/sda | grep database
Device is:        In smartctl database
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of JMicron JMS583 USB-to-SATA adapters by recognizing an additional device revision identifier.
  * Ensures compatible JMS583 units are correctly identified and continue using the SATA interface after adapter detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->