### PR TITLE
Fix lowercase capital letter  serial number string prefix

### DIFF
--- a/src/scsiprint.cpp
+++ b/src/scsiprint.cpp
@@ -3143,7 +3143,7 @@ scsiGetDriveInfo(scsi_device * device, uint8_t * peripheral_type,
 
             gBuf[4 + len] = '\0';
             scsi_format_id_string(serial, &gBuf[4], len);
-            jout("Serial number:        %s\n", serial);
+            jout("Serial Number:        %s\n", serial);
             jglb["serial_number"] = serial;
         } else if (scsi_debugmode > 0) {
             print_on();


### PR DESCRIPTION
Fix lowercase for SAS drives for aligment with SATA and NVME so now all three have "Serial Number" (I was making a script and the wrong capitalization broke it...I know I can fix it with "grep -i" instead)

**Before SAS drive:**

```
~/smartmontools/src# /usr/sbin/smartctl  -i /dev/sdb | grep -i "serial number"
Serial number:        V8J8*****
```

**After SAS drive:**
```
~/smartmontools/src# ./smartctl  -i /dev/sdb | grep -i "serial number"
Serial Number:        V8J8*****
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the SCSI drive information label from “Serial number” to “Serial Number” for consistent capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->