### PR TITLE
drivedb.h: updated Toshiba HG6 model matches (TOSHIBA THNSNJ256GMCY)

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -4619,7 +4619,7 @@ const drive_settings builtin_knowndrives[] = {
     // https://www.farnell.com/datasheets/1852757.pdf
     // TOSHIBA THNSFJ256GCSU/JULA1102
     // TOSHIBA THNSFJ256GDNU A/JYLA1102
-    "TOSHIBA THNS[NF]J(060|128|256|512)G[BCAM8VD][SCN][TU].*",
+    "TOSHIBA THNS[NF]J(060|128|256|512)G[BCAM8VD][SCN][TUY].*",
     "", "",
     "-v 167,raw48,SSD_Protect_Mode "
     "-v 168,raw48,SATA_PHY_Error_Count "

--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -4619,6 +4619,7 @@ const drive_settings builtin_knowndrives[] = {
     // https://www.farnell.com/datasheets/1852757.pdf
     // TOSHIBA THNSFJ256GCSU/JULA1102
     // TOSHIBA THNSFJ256GDNU A/JYLA1102
+    // TOSHIBA THNSNJ256GMCY
     "TOSHIBA THNS[NF]J(060|128|256|512)G[BCAM8VD][SCN][TUY].*",
     "", "",
     "-v 167,raw48,SSD_Protect_Mode "


### PR DESCRIPTION
Toshiba (now Kioxia) HG6 SSD has a previously unsupported variant with the model string ending in letter Y, as seen by this [doc][pdf] from manufacturer's website. Tested with TOSHIBA THNSNJ256GMCY with the output below:

```
$ sudo smartctl  -x -q noserial /dev/sdb
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.107+deb13-amd64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Toshiba HG6 Series SSD
Device Model:     TOSHIBA THNSNJ256GMCY
Firmware Version: JYTA0101
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      < 1.8 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database 7.3/6277
ATA Version is:   ACS-2 (minor revision not indicated)
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Thu Sep  3 11:38:06 2026 CST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM level is:     254 (maximum performance)
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, frozen [SEC2]
Wt Cache Reorder: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		(  120) seconds.
Offline data collection
capabilities: 			 (0x5b) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  10) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     -O-R--   100   100   000    -    0
  2 Throughput_Performance  P-S---   100   100   050    -    0
  3 Spin_Up_Time            POS---   100   100   050    -    0
  5 Reallocated_Sector_Ct   PO--C-   100   100   050    -    0
  7 Unknown_SSD_Attribute   PO-R--   100   100   050    -    0
  8 Unknown_SSD_Attribute   P-S---   100   100   050    -    0
  9 Power_On_Hours          -O--C-   100   100   000    -    27727
 10 Unknown_SSD_Attribute   PO--C-   100   100   050    -    0
 12 Power_Cycle_Count       -O--C-   100   100   000    -    394
167 SSD_Protect_Mode        -O---K   100   100   000    -    0
168 SATA_PHY_Error_Count    -O--C-   100   100   000    -    0
169 Bad_Block_Count         PO--C-   100   100   010    -    100
170 Unknown_Attribute       PO--C-   100   100   010    -    0
173 Erase_Count             PO--C-   193   193   100    -    0
175 Program_Fail_Count_Chip PO--C-   100   100   010    -    0
192 Power-Off_Retract_Count -O--C-   100   100   000    -    265
194 Temperature_Celsius     -O---K   043   001   000    -    57 (Min/Max 24/105)
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
240 Unknown_SSD_Attribute   PO--C-   100   100   050    -    0
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O     51  Comprehensive SMART error log
0x03       GPL     R/O     64  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x09           SL  R/W      1  Selective self-test log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (64 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Extended offline    Completed without error       00%     18882         -
# 2  Extended offline    Completed without error       00%     10670         -
# 3  Extended offline    Completed without error       00%      8370         -
# 4  Extended offline    Completed without error       00%      5077         -
# 5  Extended offline    Completed without error       00%      3195         -
# 6  Extended offline    Completed without error       00%      1832         -
# 7  Short offline       Completed without error       00%       448         -
# 8  Extended offline    Completed without error       00%         0         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       3 (0x0003)
Device State:                        Active (0)
Current Temperature:                    57 Celsius
Power Cycle Min/Max Temperature:     38/78 Celsius
Lifetime    Min/Max Temperature:     24/105 Celsius
Under/Over Temperature Limit Count:   0/48539
Vendor specific:
00 00 04 00 05 01 00 05 05 00 00 00 00 00 00 00
00 01 00 00 db 1d f3 05 01 01 00 00 00 00 00 06

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      5/40 Celsius
Min/Max Temperature Limit:            0/80 Celsius
Temperature History Size (Index):    128 (34)

Index    Estimated Time   Temperature Celsius
  35    2026-09-03 09:31    54  ***********************************
 ...    ..(  3 skipped).    ..  ***********************************
  39    2026-09-03 09:35    54  ***********************************
  40    2026-09-03 09:36    55  ************************************
  41    2026-09-03 09:37    56  *************************************
 ...    ..(  2 skipped).    ..  *************************************
  44    2026-09-03 09:40    56  *************************************
  45    2026-09-03 09:41    55  ************************************
  46    2026-09-03 09:42    55  ************************************
  47    2026-09-03 09:43    56  *************************************
  48    2026-09-03 09:44    56  *************************************
  49    2026-09-03 09:45    55  ************************************
  50    2026-09-03 09:46    55  ************************************
  51    2026-09-03 09:47    55  ************************************
  52    2026-09-03 09:48    56  *************************************
  53    2026-09-03 09:49    56  *************************************
  54    2026-09-03 09:50    55  ************************************
  55    2026-09-03 09:51    56  *************************************
  56    2026-09-03 09:52    56  *************************************
  57    2026-09-03 09:53    56  *************************************
  58    2026-09-03 09:54    57  **************************************
  59    2026-09-03 09:55    56  *************************************
  60    2026-09-03 09:56    57  **************************************
  61    2026-09-03 09:57    57  **************************************
  62    2026-09-03 09:58    56  *************************************
  63    2026-09-03 09:59    57  **************************************
  64    2026-09-03 10:00    56  *************************************
 ...    ..(  3 skipped).    ..  *************************************
  68    2026-09-03 10:04    56  *************************************
  69    2026-09-03 10:05    57  **************************************
  70    2026-09-03 10:06    56  *************************************
 ...    ..(  7 skipped).    ..  *************************************
  78    2026-09-03 10:14    56  *************************************
  79    2026-09-03 10:15    57  **************************************
  80    2026-09-03 10:16    57  **************************************
  81    2026-09-03 10:17    56  *************************************
  82    2026-09-03 10:18    56  *************************************
  83    2026-09-03 10:19    56  *************************************
  84    2026-09-03 10:20    57  **************************************
  85    2026-09-03 10:21    56  *************************************
  86    2026-09-03 10:22    56  *************************************
  87    2026-09-03 10:23    57  **************************************
  88    2026-09-03 10:24    56  *************************************
  89    2026-09-03 10:25    57  **************************************
 ...    ..(  8 skipped).    ..  **************************************
  98    2026-09-03 10:34    57  **************************************
  99    2026-09-03 10:35    58  ***************************************
 ...    ..(  4 skipped).    ..  ***************************************
 104    2026-09-03 10:40    58  ***************************************
 105    2026-09-03 10:41    59  ****************************************
 106    2026-09-03 10:42    58  ***************************************
 107    2026-09-03 10:43    58  ***************************************
 108    2026-09-03 10:44    59  ****************************************
 109    2026-09-03 10:45    59  ****************************************
 110    2026-09-03 10:46    58  ***************************************
 ...    ..(  2 skipped).    ..  ***************************************
 113    2026-09-03 10:49    58  ***************************************
 114    2026-09-03 10:50    59  ****************************************
 115    2026-09-03 10:51    59  ****************************************
 116    2026-09-03 10:52    58  ***************************************
 117    2026-09-03 10:53    58  ***************************************
 118    2026-09-03 10:54    59  ****************************************
 119    2026-09-03 10:55    58  ***************************************
 ...    ..(  3 skipped).    ..  ***************************************
 123    2026-09-03 10:59    58  ***************************************
 124    2026-09-03 11:00    57  **************************************
 125    2026-09-03 11:01    58  ***************************************
 ...    ..(  2 skipped).    ..  ***************************************
   0    2026-09-03 11:04    58  ***************************************
   1    2026-09-03 11:05    57  **************************************
   2    2026-09-03 11:06    58  ***************************************
   3    2026-09-03 11:07    58  ***************************************
   4    2026-09-03 11:08    58  ***************************************
   5    2026-09-03 11:09    59  ****************************************
   6    2026-09-03 11:10    59  ****************************************
   7    2026-09-03 11:11    59  ****************************************
   8    2026-09-03 11:12    58  ***************************************
 ...    ..(  5 skipped).    ..  ***************************************
  14    2026-09-03 11:18    58  ***************************************
  15    2026-09-03 11:19    57  **************************************
 ...    ..( 18 skipped).    ..  **************************************
  34    2026-09-03 11:38    57  **************************************

SCT Error Recovery Control:
           Read:    600 (60.0 seconds)
          Write:    600 (60.0 seconds)

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 2) ==
0x01  0x008  4             394  ---  Lifetime Power-On Resets
0x01  0x018  6     28811932109  ---  Logical Sectors Written
0x01  0x020  6       590539800  ---  Number of Write Commands
0x01  0x028  6     13178864382  ---  Logical Sectors Read
0x01  0x030  6        82940792  ---  Number of Read Commands
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               0  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              57  ---  Current Temperature
0x05  0x010  1              49  ---  Average Short Term Temperature
0x05  0x018  1              48  ---  Average Long Term Temperature
0x05  0x020  1             103  ---  Highest Temperature
0x05  0x028  1              35  ---  Lowest Temperature
0x05  0x030  1              77  ---  Highest Average Short Term Temperature
0x05  0x038  1              36  ---  Lowest Average Short Term Temperature
0x05  0x040  1              60  ---  Highest Average Long Term Temperature
0x05  0x048  1              40  ---  Lowest Average Long Term Temperature
0x05  0x050  4         1556920  ---  Time in Over-Temperature
0x05  0x058  1              40  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               5  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4             986  ---  Number of Hardware Resets
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               7  N--  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c) not supported

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  2            0  Command failed due to ICRC error
0x0002  4            0  R_ERR response for data FIS
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0005  4            0  R_ERR response for non-data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
0x0008  2            0  Device-to-host non-data FIS retries
0x0009  4     30030625  Transition from drive PhyRdy to drive PhyNRdy
0x000a  4           15  Device-to-host register FISes sent due to a COMRESET
0x000b  4            0  CRC errors within host-to-device FIS
0x000d  4            0  Non-CRC errors within host-to-device FIS
0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC
```

[pdf]: https://tw.kioxia.com/content/dam/kioxia/zh-tw/business/tw-rohs/asset/KIOXIA_BSMI_RoHS_DoC_Quark1.5z(HG6z)_mSATA.pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Toshiba HG6 Series SSD detection to recognize additional model variants containing `Y` in the relevant model position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->