### PR TITLE
drivedb.h: HPe OEM VK000480GXNZA SSDs

### DIFF
--- a/drivedb/drivedb.h
+++ b/drivedb/drivedb.h
@@ -1876,6 +1876,12 @@ const drive_settings builtin_knowndrives[] = {
     "-v 243,raw48,NAND_Writes_32MiB " // S3510/3610
     "-F xerrorlba" // tested with SSDSC2BB600G4/D2010355
   },
+  { "", // HPE VK-series SATA SSD (OEM/controller unidentified), tested with VK000480GXNZA/HPG1
+    "VK000480GXNZA",
+    "HPG1",
+    "",
+    "-v 173,raw48,Media_Wearout_Indicator "
+  },
   { "Intel SSD Pro 5400s Series", // Tested with SSDSC2KF480H6/LSF036P,
       // INTEL SSDSC2KF256H6 SATA 256GB/LBFD16N
     "INTEL SSDSC[2K]KF((120|180|240|256|360|480|512)H|010X)6( .*)?",


### PR DESCRIPTION
Add limited support for HPe OEM VK000480GXNZA SSDs

Example output from device with firmware HPG1:

```
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-5.14.0-570.132.1.el9_6.x86_64] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     VK000480GXNZA
Serial Number:    24514D013F25
LU WWN Device Id: 5 00a075 14d013f25
Firmware Version: HPG1
User Capacity:    480,103,981,056 bytes [480 GB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
TRIM Command:     Available, deterministic, zeroed
Device is:        In smartctl database
ATA Version is:   ACS-3 (minor revision not indicated)
SATA Version is:  SATA 3.3, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Fri Sep  4 19:03:51 2026 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Disabled
DSN feature is:   Unavailable
ATA Security is:  Unavailable

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever
                                        been run.
Total time to complete Offline
data collection:                ( 1674) seconds.
Offline data collection
capabilities:                    (0x7b) SMART execute Offline immediate.
                                        Auto Offline data collection on/off support.
                                        Suspend Offline collection upon new
                                        command.
                                        Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0003) Saves SMART data before entering
                                        power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        (   6) minutes.
Conveyance self-test routine
recommended polling time:        (   3) minutes.
SCT capabilities:              (0x0035) SCT Status supported.
                                        SCT Feature Control supported.
                                        SCT Data Table supported.

SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     POSR--   100   100   050    -    0
  5 Reallocated_Sector_Ct   PO--CK   100   100   010    -    0
  9 Power_On_Hours          -O--CK   100   100   000    -    13110
 11 Unknown_SSD_Attribute   -O--C-   100   100   000    -    66
 12 Power_Cycle_Count       -O--CK   100   100   000    -    94
171 Unknown_Attribute       -O--CK   100   100   000    -    0
172 Unknown_Attribute       -O--CK   100   100   000    -    0
173 Media_Wearout_Indicator PO--CK   097   097   010    -    175
174 Unknown_Attribute       -O--CK   100   100   000    -    66
175 Program_Fail_Count_Chip PO--CK   100   100   001    -    0
180 Unused_Rsvd_Blk_Cnt_Tot PO-RCK   100   100   001    -    0
184 End-to-End_Error        -O--CK   100   100   000    -    0
187 Reported_Uncorrect      -O--CK   100   100   000    -    0
188 Command_Timeout         -O--CK   100   100   000    -    225
194 Temperature_Celsius     -O---K   069   055   000    -    31 (Min/Max 12/45)
196 Reallocated_Event_Count PO--CK   100   100   001    -    0
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
198 Offline_Uncorrectable   ----C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    -OSRCK   100   100   000    -    0
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x03       GPL     R/O  16383  Ext. Comprehensive SMART error log
0x04       GPL,SL  R/O      8  Device Statistics log
0x07       GPL     R/O      1  Extended self-test log
0x08       GPL     R/O      2  Power Conditions log
0x09           SL  R/W      1  Selective self-test log
0x0c       GPL     R/O     16  Pending Defects log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x30       GPL     R/O      9  IDENTIFY DEVICE data log
0x80       GPL     R/W     16  Host vendor specific log
0x81-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xa0       GPL     VS   35328  Device vendor specific log
0xa1       GPL,SL  VS       4  Device vendor specific log
0xa3       GPL     VS   13824  Device vendor specific log
0xa5       GPL     VS    8000  Device vendor specific log
0xa5       SL      VS      64  Device vendor specific log
0xa6       GPL     VS    8000  Device vendor specific log
0xa6       SL      VS      64  Device vendor specific log
0xa7       GPL     VS   32768  Device vendor specific log
0xb5           SL  VS       1  Device vendor specific log
0xb6       GPL     VS    8193  Device vendor specific log
0xbb       GPL     VS       1  Device vendor specific log
0xd0       GPL     VS       1  Device vendor specific log
0xd7       GPL     VS       1  Device vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (16383 sectors)
No Errors Logged

SMART Error Log not supported

SMART Extended Self-test Log Version: 1 (1 sectors)
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Self-test Log not supported

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       1 (0x0001)
Device State:                        Active (0)
Current Temperature:                    31 Celsius
Power Cycle Min/Max Temperature:     22/31 Celsius
Lifetime    Min/Max Temperature:     12/45 Celsius
Specified Max Operating Temperature:    60 Celsius
Under/Over Temperature Limit Count:   0/0
Minimum supported ERC Time Limit:    50 (5.0 seconds)

SCT Temperature History Version:     2
Temperature Sampling Period:         1 minute
Temperature Logging Interval:        1 minute
Min/Max recommended Temperature:      0/60 Celsius
Min/Max Temperature Limit:            0/70 Celsius
Temperature History Size (Index):    478 (239)

Index    Estimated Time   Temperature Celsius
 240    2026-09-04 11:06    31  ************
 241    2026-09-04 11:07    30  ***********
 242    2026-09-04 11:08    31  ************
 ...    ..(149 skipped).    ..  ************
 392    2026-09-04 13:38    31  ************
 393    2026-09-04 13:39    30  ***********
 394    2026-09-04 13:40    30  ***********
 395    2026-09-04 13:41    31  ************
 ...    ..(  2 skipped).    ..  ************
 398    2026-09-04 13:44    31  ************
 399    2026-09-04 13:45    30  ***********
 400    2026-09-04 13:46    31  ************
 ...    ..( 76 skipped).    ..  ************
 477    2026-09-04 15:03    31  ************
   0    2026-09-04 15:04    30  ***********
 ...    ..(218 skipped).    ..  ***********
 219    2026-09-04 18:43    30  ***********
 220    2026-09-04 18:44    31  ************
 221    2026-09-04 18:45    30  ***********
 222    2026-09-04 18:46    30  ***********
 223    2026-09-04 18:47    31  ************
 224    2026-09-04 18:48    30  ***********
 225    2026-09-04 18:49    30  ***********
 226    2026-09-04 18:50    31  ************
 227    2026-09-04 18:51    30  ***********
 228    2026-09-04 18:52    30  ***********
 229    2026-09-04 18:53    31  ************
 230    2026-09-04 18:54    30  ***********
 231    2026-09-04 18:55    31  ************
 232    2026-09-04 18:56    31  ************
 233    2026-09-04 18:57    30  ***********
 234    2026-09-04 18:58    30  ***********
 235    2026-09-04 18:59    31  ************
 236    2026-09-04 19:00    31  ************
 237    2026-09-04 19:01    31  ************
 238    2026-09-04 19:02    30  ***********
 239    2026-09-04 19:03    31  ************

SCT Error Recovery Control command not supported

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 3) ==
0x01  0x008  4              94  ---  Lifetime Power-On Resets
0x01  0x010  4           13110  ---  Power-on Hours
0x01  0x018  6    118262726704  ---  Logical Sectors Written
0x01  0x020  6      3367506263  ---  Number of Write Commands
0x01  0x028  6   2942765935967  ---  Logical Sectors Read
0x01  0x030  6     13047814078  ---  Number of Read Commands
0x01  0x038  6     47197642800  ---  Date and Time TimeStamp
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4             225  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              31  ---  Current Temperature
0x05  0x010  1              27  ---  Average Short Term Temperature
0x05  0x018  1              19  ---  Average Long Term Temperature
0x05  0x020  1              45  ---  Highest Temperature
0x05  0x028  1              12  ---  Lowest Temperature
0x05  0x030  1              43  ---  Highest Average Short Term Temperature
0x05  0x038  1              18  ---  Lowest Average Short Term Temperature
0x05  0x040  1              25  ---  Highest Average Long Term Temperature
0x05  0x048  1              18  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              60  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               0  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4             225  ---  Number of Hardware Resets
0x06  0x010  4              59  ---  Number of ASR Events
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1               3  ---  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c)
No Defects Logged

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x0001  4            0  Command failed due to ICRC error
0x0003  4            0  R_ERR response for device-to-host data FIS
0x0004  4            0  R_ERR response for host-to-device data FIS
0x0006  4            0  R_ERR response for device-to-host non-data FIS
0x000a  4            3  Device-to-host register FISes sent due to a COMRESET
0x000b  4            0  CRC errors within host-to-device FIS
0x000d  4            0  Non-CRC errors within host-to-device FIS
```

The check passes with firmware HPG1.

```
smartctl 7.5 2025-04-30 r5714 [x86_64-linux-5.14.0-570.132.1.el9_6.x86_64] (local build)
Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org

Drive found in smartmontools Database.  Drive identity strings:
MODEL:              VK000480GXNZA
FIRMWARE:           HPG1
match smartmontools Drive Database entry:
MODEL REGEXP:       VK000480GXNZA
FIRMWARE REGEXP:    HPG1
MODEL FAMILY:
ATTRIBUTE OPTIONS:  173 Media_Wearout_Indicator
```

Note suggested from session with Antropic Claude:

- VALUE for attribute 173 (097) equals 100 minus the standardized Device Statistics 'Percentage Used Endurance Indicator' (3), confirming 173 is remaining media life.

We have 15 of these drives in our servers, VALUE for attribute 173 always matches what we see in HPe iLO (Drives -> Media Life).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drive database support for the HPE VK-series SATA SSD model VK000480GXNZA.
  * SMART attribute 173 is now identified as the Media Wearout Indicator for drives with firmware HPG1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->